### PR TITLE
Remove default event canceling

### DIFF
--- a/examples/controllers/close-warning-controller.js
+++ b/examples/controllers/close-warning-controller.js
@@ -19,7 +19,7 @@ export default class CloseWarningController extends Controller {
     }
   }
 
-  @on("~turbolinks:before-visit", document)
+  @on("turbolinks:before-visit", document)
   warnBeforeVisit(event) {
     if (this.hasUnsavedContent) {
       if (!window.confirm("Are you sure?")) {

--- a/examples/controllers/wizard-controller.js
+++ b/examples/controllers/wizard-controller.js
@@ -6,6 +6,7 @@ export default class WizardController extends Controller {
   }
 
   nextStep(event) {
+    event.preventDefault()
     this.recordStepHistory(event)
     const {currentStepElement, nextStepElement} = this
     if (nextStepElement) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -29,10 +29,6 @@ export class Action {
     return this.descriptor.methodName
   }
 
-  get preventsDefault(): boolean {
-    return this.descriptor.preventsDefault
-  }
-
   get isDirect(): boolean {
     return !this.isDelegated
   }
@@ -59,10 +55,6 @@ export class Action {
   }
 
   invokeWithEventAndTarget(event: Event, eventTarget: EventTarget) {
-    if (this.preventsDefault) {
-      event.preventDefault()
-    }
-
     this.debug("Invoking action", this, event)
 
     try {

--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -5,7 +5,6 @@ export interface DescriptorOptions {
   targetName?: string
   eventName?: string
   methodName?: string
-  preventsDefault?: boolean
 }
 
 export class Descriptor {
@@ -22,7 +21,6 @@ export class Descriptor {
   targetName: string | null
   eventName: string
   methodName: string
-  preventsDefault: boolean
 
   static forOptions(options: DescriptorOptions): Descriptor {
     return new Descriptor(
@@ -30,7 +28,6 @@ export class Descriptor {
       options.targetName || null,
       options.eventName  || error("Missing event name in descriptor"),
       options.methodName || error("Missing method name in descriptor"),
-      options.preventsDefault || false
     )
   }
 
@@ -46,12 +43,11 @@ export class Descriptor {
 
   private static parseOptionsFromInlineActionDescriptorString(descriptorString: string): DescriptorOptions {
     const source = descriptorString.trim()
-    const matches = source.match(/^(~)?((.+?)->)?(.+?)#(.+)$/) || error("Invalid descriptor syntax")
+    const matches = source.match(/^((.+?)->)?(.+?)#(.+)$/) || error("Invalid descriptor syntax")
     return {
-      identifier: matches[4],
-      eventName: matches[3],
-      methodName: matches[5],
-      preventsDefault: matches[1] ? false : true
+      identifier: matches[3],
+      eventName: matches[2],
+      methodName: matches[4]
     }
   }
 
@@ -59,12 +55,11 @@ export class Descriptor {
     return this.defaultEventNames[element.tagName.toLowerCase()](element)
   }
 
-  constructor(identifier: string, targetName: string | null, eventName: string, methodName: string, preventsDefault: boolean) {
+  constructor(identifier: string, targetName: string | null, eventName: string, methodName: string) {
     this.identifier = identifier
     this.targetName = targetName
     this.eventName = eventName
     this.methodName = methodName
-    this.preventsDefault = preventsDefault
   }
 
   isEqualTo(descriptor: Descriptor | null): boolean {
@@ -72,13 +67,11 @@ export class Descriptor {
       descriptor.identifier == this.identifier &&
       descriptor.targetName == this.targetName &&
       descriptor.eventName == this.eventName &&
-      descriptor.methodName == this.methodName &&
-      descriptor.preventsDefault == this.preventsDefault
+      descriptor.methodName == this.methodName
   }
 
   toString(): string {
-    return (this.preventsDefault ? "" : "~") +
-      `${this.eventName}->${this.identifier}#${this.methodName}`
+    return `${this.eventName}->${this.identifier}#${this.methodName}`
   }
 
   get loggerTag(): LoggerTag {

--- a/test/controller_action_test.ts
+++ b/test/controller_action_test.ts
@@ -19,7 +19,7 @@ testGroup("Controller action", function () {
 
     triggerEvent(buttonElement, "click")
     assert.equal(controller.actions.length, 1)
-    assert.deepEqual(controller.actions[0], { eventType: "click", eventPrevented: true, eventTarget: buttonElement, target: buttonElement })
+    assert.deepEqual(controller.actions[0], { eventType: "click", eventPrevented: false, eventTarget: buttonElement, target: buttonElement })
 
     done()
   })
@@ -45,7 +45,7 @@ testGroup("Controller action", function () {
 
     triggerEvent(buttonChildElement, "click")
     assert.equal(controller.actions.length, 1)
-    assert.deepEqual(controller.actions[0], { eventType: "click", eventPrevented: true, eventTarget: buttonChildElement, target: buttonElement })
+    assert.deepEqual(controller.actions[0], { eventType: "click", eventPrevented: false, eventTarget: buttonChildElement, target: buttonElement })
 
     done()
   })
@@ -106,8 +106,8 @@ testGroup("Controller action", function () {
 
     assert.equal(controller.actions.length, 2)
     assert.deepEqual(controller.actions, [
-      { eventType: "mousedown", eventPrevented: true, eventTarget: buttonElement, target: buttonElement },
-      { eventType: "mouseup", eventPrevented: true, eventTarget: buttonElement, target: buttonElement },
+      { eventType: "mousedown", eventPrevented: false, eventTarget: buttonElement, target: buttonElement },
+      { eventType: "mouseup", eventPrevented: false, eventTarget: buttonElement, target: buttonElement },
     ])
 
     done()


### PR DESCRIPTION
Removes:
-  Default `event.preventDefault()`
-  `~` inline action token to allow default (skip ↑)