### PR TITLE
Docs: Fix reference in example code

### DIFF
--- a/handbook/02_hello_stimulus.md
+++ b/handbook/02_hello_stimulus.md
@@ -183,7 +183,7 @@ export default class extends Controller {
 
   get name() {
     const target = this.targets.find("name")
-    return this.inputElement.value
+    return target.value
   }
 }
 ```


### PR DESCRIPTION
`this.inputElement` doesn’t exist. It’s extracted in the next step. Use the local `target` variable instead.