### PR TITLE
Allow to store objects

### DIFF
--- a/packages/@stimulus/core/src/data_map.ts
+++ b/packages/@stimulus/core/src/data_map.ts
@@ -17,11 +17,13 @@ export class DataMap {
 
   get(key: string): string | null {
     key = this.getFormattedKey(key)
-    return this.element.getAttribute(key)
+    const value = this.element.getAttribute(key)
+    return value ? JSON.parse(value) : null
   }
 
   set(key: string, value): string | null {
     key = this.getFormattedKey(key)
+    value = value ? JSON.stringify(value) : null
     this.element.setAttribute(key, value)
     return this.get(key)
   }

--- a/packages/@stimulus/core/test/controller_data_test.ts
+++ b/packages/@stimulus/core/test/controller_data_test.ts
@@ -8,7 +8,7 @@ testGroup("Controller data API", function () {
     const identifier = "test"
     const element = document.createElement("div")
     element.setAttribute("data-controller", identifier)
-    element.setAttribute(`data-${identifier}-foo`, "bar")
+    element.setAttribute(`data-${identifier}-foo`, JSON.stringify("bar"))
 
     this.application.register(identifier, class extends Controller {
       connect() {
@@ -31,7 +31,7 @@ testGroup("Controller data API", function () {
       connect() {
         this.data.set("foo", "bar")
         assert.equal(this.data.get("foo"), "bar")
-        assert.equal(element.getAttribute(`data-${identifier}-foo`), "bar")
+        assert.equal(element.getAttribute(`data-${identifier}-foo`), JSON.stringify("bar"))
         done()
       }
     })


### PR DESCRIPTION
I'm currently building an uploader component and I figured that it would be nice to have a way to store objects in data. For example:

I have an array of values and only one way to manipulate them right now is actually create DOM element per each value.

Where basically I want to have something like this:

```
  set storage(object) {
    const array = [...this.storage, object]
    this.data.set('storage', array)
  }

  get storage() {
    if (this.data.has('storage')) {
      return this.data.get('storage')
    } else {
      return []
    }
  }
```

I don't see a problem with using `JSON` because it has [pretty good benchmarks](https://jsperf.com/json-stringify-versions/10) and I hope people will not manipulate with 200.000 objects here.

Thank you!
  
  