### PR TITLE
Remove else clause in example

### DIFF
--- a/handbook/04_managing_state.md
+++ b/handbook/04_managing_state.md
@@ -77,9 +77,9 @@ export default class extends Controller {
   get index() {
     if (this.data.has("index")) {
       return parseInt(this.data.get("index"))
-    } else {
-      return 0
     }
+    
+    return 0
   }
 ```
 


### PR DESCRIPTION
Not really sure what your convention on this sort of thing is, but this just simplifies the example by replacing an `else` clause with a regular return.