### PR TITLE
Add Application.prototype.handleError

### DIFF
--- a/packages/@stimulus/core/src/action.ts
+++ b/packages/@stimulus/core/src/action.ts
@@ -48,7 +48,7 @@ export class Action implements EventListenerObject {
     try {
       this.method.call(this.controller, event, event.currentTarget)
     } catch (error) {
-      this.context.reportError(error, `invoking action "${this.descriptor}"`, event, this)
+      this.context.handleError(error, `invoking action "${this.descriptor}"`, { event })
     }
   }
 

--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -2,9 +2,12 @@ import { Configuration, ConfigurationOptions, createConfiguration } from "./conf
 import { Controller, ControllerConstructor } from "./controller"
 import { Router } from "./router"
 
+export type ErrorHandler = (error: Error, message: string, detail: object) => any
+
 export class Application {
   readonly configuration: Configuration
   private router: Router
+  errorHandler?: ErrorHandler
 
   static start(configurationOptions?: ConfigurationOptions): Application {
     const application = new Application(configurationOptions)
@@ -36,5 +39,20 @@ export class Application {
   getControllerForElementAndIdentifier(element: Element, identifier: string): Controller | null {
     const context = this.router.getContextForElementAndIdentifier(element, identifier)
     return context ? context.controller : null
+  }
+
+  // Error handling
+
+  setErrorHandler(errorHandler: ErrorHandler) {
+    this.errorHandler = errorHandler
+  }
+
+  /** @private */
+  handleError(error: Error, message: string, detail: object) {
+    if (typeof this.errorHandler == "function") {
+      this.errorHandler(error, message, detail)
+    } else {
+      console.error(`%s\n\n%o\n\n%o`, message, error, detail)
+    }
   }
 }

--- a/packages/@stimulus/core/src/application.ts
+++ b/packages/@stimulus/core/src/application.ts
@@ -2,12 +2,9 @@ import { Configuration, ConfigurationOptions, createConfiguration } from "./conf
 import { Controller, ControllerConstructor } from "./controller"
 import { Router } from "./router"
 
-export type ErrorHandler = (error: Error, message: string, detail: object) => any
-
 export class Application {
   readonly configuration: Configuration
   private router: Router
-  errorHandler?: ErrorHandler
 
   static start(configurationOptions?: ConfigurationOptions): Application {
     const application = new Application(configurationOptions)
@@ -43,16 +40,7 @@ export class Application {
 
   // Error handling
 
-  setErrorHandler(errorHandler: ErrorHandler) {
-    this.errorHandler = errorHandler
-  }
-
-  /** @private */
   handleError(error: Error, message: string, detail: object) {
-    if (typeof this.errorHandler == "function") {
-      this.errorHandler(error, message, detail)
-    } else {
-      console.error(`%s\n\n%o\n\n%o`, message, error, detail)
-    }
+    console.error(`%s\n\n%o\n\n%o`, message, error, detail)
   }
 }

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -25,7 +25,7 @@ export class Context implements InlineActionObserverDelegate {
       this.controller = new contextSet.controllerConstructor(this)
       this.controller.initialize()
     } catch (error) {
-      this.reportError(error, `initializing controller "${this.identifier}"`)
+      this.handleError(error, "initializing controller")
     }
   }
 
@@ -36,7 +36,7 @@ export class Context implements InlineActionObserverDelegate {
     try {
       this.controller.connect()
     } catch (error) {
-      this.reportError(error, `connecting controller "${this.identifier}"`)
+      this.handleError(error, "connecting controller")
     }
   }
 
@@ -44,7 +44,7 @@ export class Context implements InlineActionObserverDelegate {
     try {
       this.controller.disconnect()
     } catch (error) {
-      this.reportError(error, `disconnecting controller "${this.identifier}"`)
+      this.handleError(error, "disconnecting controller")
     }
 
     this.inlineActionObserver.stop()
@@ -111,12 +111,12 @@ export class Context implements InlineActionObserverDelegate {
     this.removeAction(action)
   }
 
-  // Logging
+  // Error handling
 
-  reportError(error, message, ...args) {
-    const argsFormat = args.map(arg => "%o").join("\n")
-    const format = `Error %s\n\n%o\n\n${argsFormat}\n%o\n%o`
-    return console.error(format, message, error, ...args, this.controller, this.element)
+  handleError(error: Error, message: string, detail: object = {}) {
+    const { identifier, controller, element } = this
+    detail = Object.assign({ identifier, controller, element }, detail)
+    this.application.handleError(error, `Error ${message}`, detail)
   }
 }
 

--- a/packages/@stimulus/core/src/inline_action_observer.ts
+++ b/packages/@stimulus/core/src/inline_action_observer.ts
@@ -89,7 +89,7 @@ export class InlineActionObserver implements TokenListObserverDelegate {
         return new Action(this.context, descriptor, descriptor.eventTarget)
       }
     } catch (error) {
-      this.context.reportError(error, `parsing descriptor string "${descriptorString}" for element`, element)
+      this.context.handleError(error, `parsing descriptor string "${descriptorString}"`, { element })
     }
   }
 }


### PR DESCRIPTION
Supply your own error handler function to override the default `console.error`. Useful for sending errors to a tracking service like Sentry.

```js
const application = Application.start()

application.handleError = (error, message, detail) => {
  console.warn(message, detail)
  Raven.captureException(error)
}
```