### PR TITLE
Invoke action methods with event only

### DIFF
--- a/packages/@stimulus/core/src/action.ts
+++ b/packages/@stimulus/core/src/action.ts
@@ -46,7 +46,7 @@ export class Action implements EventListenerObject {
 
   private invokeWithEvent(event: Event) {
     try {
-      this.method.call(this.controller, event, event.currentTarget)
+      this.method.call(this.controller, event)
     } catch (error) {
       this.context.reportError(error, `invoking action "${this.descriptor}"`, event, this)
     }

--- a/packages/@stimulus/core/test/test_helpers.ts
+++ b/packages/@stimulus/core/test/test_helpers.ts
@@ -97,11 +97,11 @@ export class TestController extends Controller {
     this.lifecycle.disconnect++
   }
 
-  foo(event, target) {
-    this.recordAction(event, target)
+  foo(event) {
+    this.recordAction(event)
   }
 
-  private recordAction(event: Event, target: EventTarget) {
-    this.actions.push({ eventType: event.type, eventPrevented: event.defaultPrevented, eventTarget: event.target, target: target })
+  private recordAction(event: Event) {
+    this.actions.push({ eventType: event.type, eventPrevented: event.defaultPrevented, eventTarget: event.target, target: event.currentTarget })
   }
 }


### PR DESCRIPTION
The event target argument passed to action methods is a vestige of event delegation, which was removed in https://github.com/stimulusjs/stimulus/pull/16.

With event delegation, you couldn't rely on `event.target` or `event.currentTarget` being the action element so we started passing it directly (6862d199960ac3923b75571f7f876ff33ecfd4e4). Now you just use `event.currentTarget` in action methods.