### PR TITLE
Namespaced identifiers

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -10,7 +10,7 @@ To install Stimulus, add the [`stimulus` npm package](https://www.npmjs.com/pack
 
 Stimulus integrates with the [webpack](https://webpack.js.org/) asset packager to automatically load controller files from a folder in your app.
 
-Use webpack's [`require.context`](https://webpack.js.org/api/module-methods/#require-context) helper in conjunction with Stimulus' `definitionsFromContext` helper to set everything up:
+Call webpack's [`require.context`](https://webpack.js.org/api/module-methods/#require-context) helper with the path to the folder containing your Stimulus controllers. Then, pass the resulting context to the `Application#load` method using the `definitionsFromContext` helper:
 
 ```js
 // src/application.js
@@ -22,13 +22,22 @@ const context = require.context("./controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))
 ```
 
-Then name your controller files `[identifier]_controller.js` (or `[identifier]-controller.js` if you prefer dashes), where `identifier` corresponds to each controller's `data-controller` identifier in your HTML.
+### Controller Filenames Map to Identifiers
 
-**Note**: Always use dashes in `data-controller` values for multi-word controller `identifier`s.
+Name your controller files `[identifier]_controller.js`, where `identifier` corresponds to each controller's `data-controller` identifier in your HTML.
 
-Examples:
-* `data-controller="clipboard"` → `clipboard_controller.js` or `clipboard-controller.js`
-* `data-controller="local-time"` → `local_time_controller.js` or `local-time-controller.js`
+Stimulus conventionally separates multiple words in filenames using underscores. Each underscore in a controller's filename translates to a dash in its identifier.
+
+You may also namespace your controllers using subfolders. Each forward slash in a namespaced controller file's path becomes two dashes in its identifier.
+
+If you prefer, you may use dashes instead of underscores anywhere in a controller's filename. Stimulus treats them identically.
+
+If your controller file is named… | its identifier will be…
+--------------------------------- | -----------------------
+clipboard_controller.js           | clipboard
+date_picker_controller.js         | date-picker
+users/list_item_controller.js     | users--list-item
+local-time-controller.js          | local-time
 
 ## Using Other Build Systems
 

--- a/packages/@stimulus/core/test/index.ts
+++ b/packages/@stimulus/core/test/index.ts
@@ -1,5 +1,5 @@
 import "@stimulus/polyfills"
 
 const context = require.context("./cases", true, /\.ts$/)
-const modules = context.keys().map(key => [key.slice(2), context(key).default])
-modules.forEach(([path, constructor]) => constructor.defineModule(constructor.name || path))
+const modules = context.keys().map(key => context(key).default)
+modules.forEach(constructor => constructor.defineModule())

--- a/packages/@stimulus/test/src/test_case.ts
+++ b/packages/@stimulus/test/src/test_case.ts
@@ -1,7 +1,7 @@
 export class TestCase {
   readonly assert: Assert
 
-  static defineModule(moduleName: string, qUnit: QUnit = QUnit) {
+  static defineModule(moduleName: string = this.name, qUnit: QUnit = QUnit) {
     qUnit.module(moduleName, hooks => {
       this.manifest.forEach(([type, name]) => {
         const method = qUnit[type] as Function

--- a/packages/@stimulus/webpack-helpers/index.ts
+++ b/packages/@stimulus/webpack-helpers/index.ts
@@ -25,13 +25,9 @@ function definitionForModuleAndIdentifier(module: ECMAScriptModule, identifier: 
   }
 }
 
-function identifierForContextKey(key: string): string | undefined {
-  const dasherizedKey = key.replace(/_/g, "-")
-  const matches = dasherizedKey.match(/([\w-]+)-controller(\.\w+)?$/i)
-  if (matches) {
-    const identifier = matches[1].replace(/-controller$/i, "")
-    if (identifier) {
-      return identifier
-    }
+export function identifierForContextKey(key: string): string | undefined {
+  const logicalName = (key.match(/^(?:\.\/)?(.+)(?:[_-]controller\..+?)$/) || [])[1]
+  if (logicalName) {
+    return logicalName.replace(/_/g, "-").replace(/\//g, "--")
   }
 }

--- a/packages/@stimulus/webpack-helpers/test/index.ts
+++ b/packages/@stimulus/webpack-helpers/test/index.ts
@@ -1,0 +1,32 @@
+import { TestCase } from "@stimulus/test"
+import { identifierForContextKey } from "../index"
+
+(class WebpackHelperTests extends TestCase {
+  "test filenames require an extension"() {
+    this.assertContextKeyMapsToIdentifier("./hello_controller", undefined)
+    this.assertContextKeyMapsToIdentifier("./hello_controller.js", "hello")
+    this.assertContextKeyMapsToIdentifier("./hello_controller.ts", "hello")
+  }
+
+  "test filenames require a controller suffix"() {
+    this.assertContextKeyMapsToIdentifier("./hello.js", undefined)
+    this.assertContextKeyMapsToIdentifier("./hello_world.js", undefined)
+    this.assertContextKeyMapsToIdentifier("./hello_controller.js", "hello")
+    this.assertContextKeyMapsToIdentifier("./hello-controller.js", "hello")
+  }
+
+  "test underscores map to one dash"() {
+    this.assertContextKeyMapsToIdentifier("./remote_content_controller.js", "remote-content")
+    this.assertContextKeyMapsToIdentifier("./date_range_editor_controller.js", "date-range-editor")
+  }
+
+  "test slashes map to two dashes"() {
+    this.assertContextKeyMapsToIdentifier("./users/list_item_controller.js", "users--list-item")
+    this.assertContextKeyMapsToIdentifier("./my/navigation/menu_controller.js", "my--navigation--menu")
+  }
+
+  assertContextKeyMapsToIdentifier(contextKey, expectedIdentifier) {
+    const actualIdentifier = identifierForContextKey(contextKey)
+    this.assert.equal(actualIdentifier, expectedIdentifier)
+  }
+}).defineModule()


### PR DESCRIPTION
This branch adds support for directory-namespaced controllers in `@stimulus/webpack-helpers`. It does this by mapping `/` in controller filenames to `--`, which makes the identifier safe for use in HTML attributes (and thus compatible with the Stimulus data API).

```js
// controllers/users/list_item_controller.js
export default class extends Controller {
  get indexValue() {
    return this.data.get("index")
  }
}
```

```html
<div data-controller="users--list-item" data-users--list-item-index="0">...</div>
```