### PR TITLE
Introduce a `Controller.bless` hook

### DIFF
--- a/packages/@stimulus/core/src/controller.ts
+++ b/packages/@stimulus/core/src/controller.ts
@@ -3,15 +3,21 @@ import { Context } from "./context"
 import { DataMap } from "./data_map"
 import { Scope } from "./scope"
 import { TargetSet } from "./target_set"
+import { defineTargetProperties } from "./target_properties"
 
 export interface ControllerConstructor {
-  targets: string[]
+  import()
   new(context: Context): Controller
 }
 
 export class Controller {
   static targets: string[] = []
+
   readonly context: Context
+
+  static import() {
+    defineTargetProperties(this)
+  }
 
   constructor(context: Context) {
     this.context = context

--- a/packages/@stimulus/core/src/controller.ts
+++ b/packages/@stimulus/core/src/controller.ts
@@ -6,7 +6,7 @@ import { TargetSet } from "./target_set"
 import { defineTargetProperties } from "./target_properties"
 
 export interface ControllerConstructor {
-  import()
+  bless()
   new(context: Context): Controller
 }
 
@@ -15,7 +15,7 @@ export class Controller {
 
   readonly context: Context
 
-  static import() {
+  static bless() {
     defineTargetProperties(this)
   }
 

--- a/packages/@stimulus/core/src/definition.ts
+++ b/packages/@stimulus/core/src/definition.ts
@@ -6,53 +6,14 @@ export interface Definition {
 }
 
 export function importDefinition(definition: Definition): Definition {
-  const importer = new DefinitionImporter(definition)
-  return importer.definition
-}
-
-class DefinitionImporter {
-  identifier: string
-  controllerConstructor: ControllerConstructor
-
-  constructor({ identifier, controllerConstructor }: Definition) {
-    this.identifier = identifier
-    this.controllerConstructor = class extends controllerConstructor {}
-    this.defineTargetProperties()
-  }
-
-  get definition(): Definition {
-    const { identifier, controllerConstructor } = this
-    return { identifier, controllerConstructor }
-  }
-
-  private defineTargetProperties() {
-    this.targetNames.forEach(targetName => {
-      this.defineProperty(`${targetName}Target`, {
-        get() { return this.targets.find(targetName) }
-      })
-      this.defineProperty(`${targetName}Targets`, {
-        get() { return this.targets.findAll(targetName) }
-      })
-    })
-  }
-
-  private defineProperty(name: string, descriptor: PropertyDescriptor) {
-    const { prototype } = this.controllerConstructor
-    if (name in prototype) return
-    Object.defineProperty(prototype, name, descriptor)
-  }
-
-  private get targetNames(): string[] {
-    const names = new Set
-    let { controllerConstructor } = this
-    while (controllerConstructor) {
-      const { targets } = controllerConstructor
-      if (Array.isArray(targets)) {
-        targets.forEach(name => names.add(name))
-      }
-      controllerConstructor = Object.getPrototypeOf(controllerConstructor)
-    }
-    return Array.from(names)
+  return {
+    identifier: definition.identifier,
+    controllerConstructor: importControllerConstructor(definition.controllerConstructor)
   }
 }
 
+function importControllerConstructor(controllerConstructor: ControllerConstructor): ControllerConstructor {
+  const constructor = class extends controllerConstructor { }
+  constructor.import()
+  return constructor
+}

--- a/packages/@stimulus/core/src/definition.ts
+++ b/packages/@stimulus/core/src/definition.ts
@@ -5,15 +5,15 @@ export interface Definition {
   controllerConstructor: ControllerConstructor
 }
 
-export function importDefinition(definition: Definition): Definition {
+export function blessDefinition(definition: Definition): Definition {
   return {
     identifier: definition.identifier,
-    controllerConstructor: importControllerConstructor(definition.controllerConstructor)
+    controllerConstructor: blessControllerConstructor(definition.controllerConstructor)
   }
 }
 
-function importControllerConstructor(controllerConstructor: ControllerConstructor): ControllerConstructor {
+function blessControllerConstructor(controllerConstructor: ControllerConstructor): ControllerConstructor {
   const constructor = class extends controllerConstructor { }
-  constructor.import()
+  constructor.bless()
   return constructor
 }

--- a/packages/@stimulus/core/src/module.ts
+++ b/packages/@stimulus/core/src/module.ts
@@ -1,7 +1,7 @@
 import { Application } from "./application"
 import { Context } from "./context"
 import { ControllerConstructor } from "./controller"
-import { Definition, importDefinition } from "./definition"
+import { Definition, blessDefinition } from "./definition"
 
 export class Module {
   readonly application: Application
@@ -12,7 +12,7 @@ export class Module {
 
   constructor(application: Application, definition: Definition) {
     this.application = application
-    this.definition = importDefinition(definition)
+    this.definition = blessDefinition(definition)
     this.contextsByElement = new WeakMap
     this.connectedContexts = new Set
   }

--- a/packages/@stimulus/core/src/target_properties.ts
+++ b/packages/@stimulus/core/src/target_properties.ts
@@ -1,0 +1,47 @@
+export function defineTargetProperties(constructor: Function) {
+  const prototype = constructor.prototype
+  const targetNames = getTargetNamesForConstructor(constructor)
+  targetNames.forEach(name => defineLinkedProperties(prototype, {
+    [`${name}Target`]: {
+      get() {
+        return this.targets.find(name)
+      }
+    },
+    [`${name}Targets`]: {
+      get() {
+        return this.targets.findAll(name)
+      }
+    }
+  }))
+}
+
+function getTargetNamesForConstructor(constructor: Function) {
+  const ancestors = getAncestorsForConstructor(constructor)
+  return Array.from(ancestors.reduce((targetNames, constructor) => {
+    getOwnTargetNamesForConstructor(constructor).forEach(name => targetNames.add(name))
+    return targetNames
+  }, new Set as Set<string>))
+}
+
+function getAncestorsForConstructor(constructor: Function) {
+  const ancestors: Function[] = []
+  while (constructor) {
+    ancestors.push(constructor)
+    constructor = Object.getPrototypeOf(constructor)
+  }
+  return ancestors
+}
+
+function getOwnTargetNamesForConstructor(constructor: Function) {
+  const definition = constructor["targets"]
+  return Array.isArray(definition) ? definition : []
+}
+
+function defineLinkedProperties(object: any, properties: PropertyDescriptorMap) {
+  Object.keys(properties).forEach((name) => {
+    if (object[name] === undefined) {
+      const descriptor = properties[name]
+      Object.defineProperty(object, name, descriptor)
+    }
+  })
+}

--- a/packages/@stimulus/core/src/target_properties.ts
+++ b/packages/@stimulus/core/src/target_properties.ts
@@ -39,7 +39,7 @@ function getOwnTargetNamesForConstructor(constructor: Function) {
 
 function defineLinkedProperties(object: any, properties: PropertyDescriptorMap) {
   Object.keys(properties).forEach((name) => {
-    if (object[name] === undefined) {
+    if (!(name in object)) {
       const descriptor = properties[name]
       Object.defineProperty(object, name, descriptor)
     }

--- a/packages/@stimulus/core/test/cases/application_tests.ts
+++ b/packages/@stimulus/core/test/cases/application_tests.ts
@@ -29,10 +29,12 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[0] instanceof AController)
     this.assert.equal(this.controllers[0].initializeCount, 1)
     this.assert.equal(this.controllers[0].connectCount, 1)
+    this.assert.equal(this.controllers[0].constructor["importCount"], 1)
 
     this.assert.ok(this.controllers[1] instanceof BController)
     this.assert.equal(this.controllers[1].initializeCount, 1)
     this.assert.equal(this.controllers[1].connectCount, 1)
+    this.assert.equal(this.controllers[1].constructor["importCount"], 1)
   }
 
   "test Application#unload"() {
@@ -58,6 +60,7 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[1] instanceof CController)
     this.assert.equal(this.controllers[1].initializeCount, 1)
     this.assert.equal(this.controllers[1].connectCount, 1)
+    this.assert.equal(this.controllers[1].constructor["importCount"], 1)
   }
 
   get controllers() {

--- a/packages/@stimulus/core/test/cases/application_tests.ts
+++ b/packages/@stimulus/core/test/cases/application_tests.ts
@@ -29,12 +29,12 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[0] instanceof AController)
     this.assert.equal(this.controllers[0].initializeCount, 1)
     this.assert.equal(this.controllers[0].connectCount, 1)
-    this.assert.equal(this.controllers[0].constructor["importCount"], 1)
+    this.assert.equal(this.controllers[0].constructor["blessCount"], 1)
 
     this.assert.ok(this.controllers[1] instanceof BController)
     this.assert.equal(this.controllers[1].initializeCount, 1)
     this.assert.equal(this.controllers[1].connectCount, 1)
-    this.assert.equal(this.controllers[1].constructor["importCount"], 1)
+    this.assert.equal(this.controllers[1].constructor["blessCount"], 1)
   }
 
   "test Application#unload"() {
@@ -60,7 +60,7 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[1] instanceof CController)
     this.assert.equal(this.controllers[1].initializeCount, 1)
     this.assert.equal(this.controllers[1].connectCount, 1)
-    this.assert.equal(this.controllers[1].constructor["importCount"], 1)
+    this.assert.equal(this.controllers[1].constructor["blessCount"], 1)
   }
 
   get controllers() {

--- a/packages/@stimulus/core/test/cases/lifecycle_tests.ts
+++ b/packages/@stimulus/core/test/cases/lifecycle_tests.ts
@@ -19,6 +19,7 @@ export default class LifecycleTests extends LogControllerTestCase {
     this.assert.equal(this.controller.connectCount, 1)
     await this.reconnectControllerElement()
     this.assert.equal(this.controller.connectCount, 2)
+    this.assert.equal(this.controller.constructor["importCount"], 1)
   }
 
   async "test Controller#disconnect"() {

--- a/packages/@stimulus/core/test/cases/lifecycle_tests.ts
+++ b/packages/@stimulus/core/test/cases/lifecycle_tests.ts
@@ -19,7 +19,7 @@ export default class LifecycleTests extends LogControllerTestCase {
     this.assert.equal(this.controller.connectCount, 1)
     await this.reconnectControllerElement()
     this.assert.equal(this.controller.connectCount, 2)
-    this.assert.equal(this.controller.constructor["importCount"], 1)
+    this.assert.equal(this.controller.constructor["blessCount"], 1)
   }
 
   async "test Controller#disconnect"() {

--- a/packages/@stimulus/core/test/log_controller.ts
+++ b/packages/@stimulus/core/test/log_controller.ts
@@ -8,10 +8,16 @@ export type ActionLogEntry = {
 }
 
 export class LogController extends Controller {
+  static importCount = 0
   initializeCount = 0
   connectCount = 0
   disconnectCount = 0
   actionLog: ActionLogEntry[] = []
+
+  static import() {
+    super.import()
+    this.importCount++
+  }
 
   initialize() {
     this.initializeCount++

--- a/packages/@stimulus/core/test/log_controller.ts
+++ b/packages/@stimulus/core/test/log_controller.ts
@@ -8,15 +8,15 @@ export type ActionLogEntry = {
 }
 
 export class LogController extends Controller {
-  static importCount = 0
+  static blessCount = 0
   initializeCount = 0
   connectCount = 0
   disconnectCount = 0
   actionLog: ActionLogEntry[] = []
 
-  static import() {
-    super.import()
-    this.importCount++
+  static bless() {
+    super.bless()
+    this.blessCount++
   }
 
   initialize() {


### PR DESCRIPTION
Controllers can override `static bless()` to define additional properties on the module's anonymous subclass.