### PR TITLE
Singular target properties throw an error when the element is missing

### DIFF
--- a/packages/@stimulus/core/src/target_properties.ts
+++ b/packages/@stimulus/core/src/target_properties.ts
@@ -16,6 +16,11 @@ export function defineTargetProperties(constructor: Function) {
       get() {
         return this.targets.findAll(name)
       }
+    },
+    [`has${capitalize(name)}Target`]: {
+      get() {
+        return this.targets.has(name)
+      }
     }
   }))
 }
@@ -49,4 +54,8 @@ function defineLinkedProperties(object: any, properties: PropertyDescriptorMap) 
       Object.defineProperty(object, name, descriptor)
     }
   })
+}
+
+function capitalize(name: string) {
+  return name.charAt(0).toLocaleUpperCase() + name.slice(1)
 }

--- a/packages/@stimulus/core/src/target_properties.ts
+++ b/packages/@stimulus/core/src/target_properties.ts
@@ -4,7 +4,12 @@ export function defineTargetProperties(constructor: Function) {
   targetNames.forEach(name => defineLinkedProperties(prototype, {
     [`${name}Target`]: {
       get() {
-        return this.targets.find(name)
+        const target = this.targets.find(name)
+        if (target) {
+          return target
+        } else {
+          throw new Error(`Missing target element "${this.identifier}.${name}"`)
+        }
       }
     },
     [`${name}Targets`]: {

--- a/packages/@stimulus/core/test/cases/target_tests.ts
+++ b/packages/@stimulus/core/test/cases/target_tests.ts
@@ -43,12 +43,12 @@ export default class TargetTests extends TargetControllerTestCase {
     this.assert.equal(this.findElement("#delta1"), this.controller.targets.find("delta"))
   }
 
-  "test defined target properties"() {
+  "test linked target properties"() {
     this.assert.equal(this.findElement("#beta1"), this.controller.betaTarget)
     this.assert.deepEqual(this.findElements("#beta1"), this.controller.betaTargets)
   }
 
-  "test inherited defined target properties"() {
+  "test inherited linked target properties"() {
     this.assert.equal(this.findElement("#alpha1"), this.controller.alphaTarget)
     this.assert.deepEqual(this.findElements("#alpha1", "#alpha2"), this.controller.alphaTargets)
   }

--- a/packages/@stimulus/core/test/cases/target_tests.ts
+++ b/packages/@stimulus/core/test/cases/target_tests.ts
@@ -52,4 +52,10 @@ export default class TargetTests extends TargetControllerTestCase {
     this.assert.equal(this.findElement("#alpha1"), this.controller.alphaTarget)
     this.assert.deepEqual(this.findElements("#alpha1", "#alpha2"), this.controller.alphaTargets)
   }
+
+  "test singular linked target property throws an error when no target is found"() {
+    this.findElement("#beta1").removeAttribute("data-target")
+    this.assert.equal(this.controller.betaTargets.length, 0)
+    this.assert.throws(() => this.controller.betaTarget)
+  }
 }

--- a/packages/@stimulus/core/test/cases/target_tests.ts
+++ b/packages/@stimulus/core/test/cases/target_tests.ts
@@ -46,6 +46,7 @@ export default class TargetTests extends TargetControllerTestCase {
   "test linked target properties"() {
     this.assert.equal(this.findElement("#beta1"), this.controller.betaTarget)
     this.assert.deepEqual(this.findElements("#beta1"), this.controller.betaTargets)
+    this.assert.equal(this.controller.hasBetaTarget, true)
   }
 
   "test inherited linked target properties"() {
@@ -55,6 +56,7 @@ export default class TargetTests extends TargetControllerTestCase {
 
   "test singular linked target property throws an error when no target is found"() {
     this.findElement("#beta1").removeAttribute("data-target")
+    this.assert.equal(this.controller.hasBetaTarget, false)
     this.assert.equal(this.controller.betaTargets.length, 0)
     this.assert.throws(() => this.controller.betaTarget)
   }

--- a/packages/@stimulus/core/test/cases/target_tests.ts
+++ b/packages/@stimulus/core/test/cases/target_tests.ts
@@ -15,43 +15,43 @@ export default class TargetTests extends TargetControllerTestCase {
   `
 
   "test TargetSet#find"() {
-    this.assert.equal(this.findElement("#alpha1"), this.controller.targets.find("alpha"))
+    this.assert.equal(this.controller.targets.find("alpha"), this.findElement("#alpha1"))
   }
 
   "test TargetSet#findAll"() {
     this.assert.deepEqual(
-      this.findElements("#alpha1", "#alpha2"),
-      this.controller.targets.findAll("alpha")
+      this.controller.targets.findAll("alpha"),
+      this.findElements("#alpha1", "#alpha2")
     )
   }
 
   "test TargetSet#findAll with multiple arguments"() {
     this.assert.deepEqual(
-      this.findElements("#alpha1", "#alpha2", "#beta1"),
-      this.controller.targets.findAll("alpha", "beta")
+      this.controller.targets.findAll("alpha", "beta"),
+      this.findElements("#alpha1", "#alpha2", "#beta1")
     )
   }
 
   "test TargetSet#has"() {
-    this.assert.equal(true, this.controller.targets.has("gamma"))
-    this.assert.equal(false, this.controller.targets.has("delta"))
+    this.assert.equal(this.controller.targets.has("gamma"), true)
+    this.assert.equal(this.controller.targets.has("delta"), false)
   }
 
   "test TargetSet#find ignores child controller targets"() {
-    this.assert.equal(null, this.controller.targets.find("delta"))
+    this.assert.equal(this.controller.targets.find("delta"), null)
     this.findElement("#child").removeAttribute("data-controller")
-    this.assert.equal(this.findElement("#delta1"), this.controller.targets.find("delta"))
+    this.assert.equal(this.controller.targets.find("delta"), this.findElement("#delta1"))
   }
 
   "test linked target properties"() {
-    this.assert.equal(this.findElement("#beta1"), this.controller.betaTarget)
-    this.assert.deepEqual(this.findElements("#beta1"), this.controller.betaTargets)
+    this.assert.equal(this.controller.betaTarget, this.findElement("#beta1"))
+    this.assert.deepEqual(this.controller.betaTargets, this.findElements("#beta1"))
     this.assert.equal(this.controller.hasBetaTarget, true)
   }
 
   "test inherited linked target properties"() {
-    this.assert.equal(this.findElement("#alpha1"), this.controller.alphaTarget)
-    this.assert.deepEqual(this.findElements("#alpha1", "#alpha2"), this.controller.alphaTargets)
+    this.assert.equal(this.controller.alphaTarget, this.findElement("#alpha1"))
+    this.assert.deepEqual(this.controller.alphaTargets, this.findElements("#alpha1", "#alpha2"))
   }
 
   "test singular linked target property throws an error when no target is found"() {

--- a/packages/@stimulus/core/test/target_controller.ts
+++ b/packages/@stimulus/core/test/target_controller.ts
@@ -5,6 +5,7 @@ export class BaseTargetController extends Controller {
 
   alphaTarget: Element | null
   alphaTargets: Element[]
+  hasAlphaTarget: boolean
 }
 
 export class TargetController extends BaseTargetController {
@@ -12,4 +13,5 @@ export class TargetController extends BaseTargetController {
 
   betaTarget: Element | null
   betaTargets: Element[]
+  hasBetaTarget: boolean
 }


### PR DESCRIPTION
Tired: `undefined is not an object`
Wired: `Missing target element: "clipboard.source"`

This branch fails fast, and with a more helpful error message, when using a `this.fooTarget` linked property. It also adds a new `this.hasFooTarget` boolean linked property for testing whether a target exists.