### PR TITLE
Fix inconsistent has*Target property names in different locales

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,6 +58,14 @@ if (process.env.CI) {
       browserName: "chrome",
       version: "63"
     },
+    sl_chrome_lang_tl: {
+      base: "SauceLabs",
+      browserName: "chrome",
+      version: "63",
+      chromeOptions: {
+        args: ["--lang=tr"]
+      }
+    },
     sl_firefox_43: {
       base: "SauceLabs",
       browserName: "firefox",

--- a/packages/@stimulus/core/src/target_properties.ts
+++ b/packages/@stimulus/core/src/target_properties.ts
@@ -57,5 +57,5 @@ function defineLinkedProperties(object: any, properties: PropertyDescriptorMap) 
 }
 
 function capitalize(name: string) {
-  return name.charAt(0).toLocaleUpperCase() + name.slice(1)
+  return name.charAt(0).toUpperCase() + name.slice(1)
 }

--- a/packages/@stimulus/core/test/cases/target_tests.ts
+++ b/packages/@stimulus/core/test/cases/target_tests.ts
@@ -11,6 +11,7 @@ export default class TargetTests extends TargetControllerTestCase {
       <div data-controller="${this.identifier}" id="child">
         <div data-target="${this.identifier}.delta" id="delta1"></div>
       </div>
+      <textarea data-target="${this.identifier}.input" id="input1"></textarea>
     </div>
   `
 
@@ -59,5 +60,9 @@ export default class TargetTests extends TargetControllerTestCase {
     this.assert.equal(this.controller.hasBetaTarget, false)
     this.assert.equal(this.controller.betaTargets.length, 0)
     this.assert.throws(() => this.controller.betaTarget)
+  }
+
+  "test has*Target property names are not localized"() {
+    this.assert.equal(this.controller.hasInputTarget, true)
   }
 }

--- a/packages/@stimulus/core/test/target_controller.ts
+++ b/packages/@stimulus/core/test/target_controller.ts
@@ -9,9 +9,13 @@ export class BaseTargetController extends Controller {
 }
 
 export class TargetController extends BaseTargetController {
-  static targets = [ "beta" ]
+  static targets = [ "beta", "input" ]
 
   betaTarget: Element | null
   betaTargets: Element[]
   hasBetaTarget: boolean
+
+  inputTarget: Element | null
+  inputTargets: Element[]
+  hasInputTarget: boolean
 }


### PR DESCRIPTION
Fixes at least one known case where `this.has*Target` property names would differ depending on locale. In Turkish, `i` is capitalized to `İ` so `static targets = [ "input" ]` would create a `this.hasİnputTarget` property for browsers using that locale, and `this.hasInputTarget` in others.

🙇‍♂️ to @rosa for tracking this down!

---

Further reading: [What’s Wrong With Turkey?](https://blog.codinghorror.com/whats-wrong-with-turkey/), [Dotted and dotless I](https://en.wikipedia.org/wiki/Dotted_and_dotless_I)