### PR TITLE
Add clarification on how events are supported

### DIFF
--- a/handbook/03_building_something_real.md
+++ b/handbook/03_building_something_real.md
@@ -131,6 +131,14 @@ export default class extends Controller {
 }
 ```
 >
+> Window events are supported to, for instance, this commonly deployed method for linking YouTube videos onto a site:
+
+```html
+<div data-controller="youtube" data-action="youtube-api:ready@window->youtube#init_player">
+  <div id="player">
+</div>
+```
+>
 
 Finally, in our `copy()` method, we can select the input field's contents and call the clipboard API:
 

--- a/handbook/03_building_something_real.md
+++ b/handbook/03_building_something_real.md
@@ -101,6 +101,36 @@ We want a click on the button to invoke the `copy()` method in our controller, s
 > input type=submit | click
 > select            | change
 > textarea          | change
+>
+> ### Other Events
+>
+> In case you were wondering, nearly *all* [events](https://developer.mozilla.org/en-US/docs/Web/Events) are supported using
+> the long form `event->controller#action` notation, so we have you covered there too! The controller implements the standard *`addEventListener`* API
+>
+> You can even chain controller methods together to react to events. Implementing the [drag & drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#drop) may look similiar to this, for example:
+
+```html
+<ul
+    class="list-cards"
+    data-target="dragdrop.dropzone"
+    data-action="dragover->dragdrop#acceptCard drop->dragdrop#dropCard">
+  <!-- your HTML content.... -->
+```
+
+```js
+export default class extends Controller {
+  // ...
+
+  acceptCard(event) {
+    event.preventDefault()
+  }
+
+  dropCard() {
+    // ...
+  }
+}
+```
+>
 
 Finally, in our `copy()` method, we can select the input field's contents and call the clipboard API:
 


### PR DESCRIPTION
So I have been working my way through adding stimulus to my application, and I stumbled upon the fact that it was actually somewhat unclear (to me, perhaps not others) how to support triggering other events.

Now I understand on the back side from what I can tell you're implementing the addEventListener API so that makes this easy, so I did figure out that you're simply short forming event->controller#method to the equivalent addEvenListener API. 

However, it did take me digging into the code a little to surmise this properly. I want to add a blurb to the docs that will make this clear and apparent.

The example is an example I found from an earlier issue, [issue 127](https://github.com/stimulusjs/stimulus/issues/127)

If its too verbose or whatever, let me know, but I think it would be great if the docs explicitly stated that this is how it works. Explicit vs implicit and all that jazz.