### PR TITLE
Use dot instead of double dash for clear namespacing

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -44,7 +44,7 @@ For example, this element has a controller which is an instance of the class def
 <div data-controller="reference"></div>
 ```
 
-If you have controllers within a namespace for example: 
+If you have controllers under a namespace: 
 
 ```yml
 controllers: 

--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -44,6 +44,28 @@ For example, this element has a controller which is an instance of the class def
 <div data-controller="reference"></div>
 ```
 
+If you have controllers within a namespace for example: 
+
+```yml
+controllers: 
+	admin: 
+		- reference_controller.js 
+	app: 
+		- reference_controller.js 
+```
+
+```js
+const context = require.context('../controllers', true, /\.js$/)
+application.load(definitionsFromContext(context))
+```
+
+Then, you can reference them in your views like so: 
+
+```html
+<div data-controller="admin.reference"></div>
+<div data-controller="app.reference"></div>
+```
+
 ## Scopes
 
 When Stimulus connects a controller to an element, that element and all of its children make up the controller's _scope_.

--- a/packages/@stimulus/webpack-helpers/index.ts
+++ b/packages/@stimulus/webpack-helpers/index.ts
@@ -28,6 +28,6 @@ function definitionForModuleAndIdentifier(module: ECMAScriptModule, identifier: 
 export function identifierForContextKey(key: string): string | undefined {
   const logicalName = (key.match(/^(?:\.\/)?(.+)(?:[_-]controller\..+?)$/) || [])[1]
   if (logicalName) {
-    return logicalName.replace(/_/g, "-").replace(/\//g, "--")
+    return logicalName.replace(/_/g, "-").replace(/\//g, ".")
   }
 }

--- a/packages/@stimulus/webpack-helpers/test/index.ts
+++ b/packages/@stimulus/webpack-helpers/test/index.ts
@@ -15,14 +15,14 @@ import { identifierForContextKey } from "../index"
     this.assertContextKeyMapsToIdentifier("./hello-controller.js", "hello")
   }
 
-  "test underscores map to one dash"() {
+  "test filenames underscores map to one dash"() {
     this.assertContextKeyMapsToIdentifier("./remote_content_controller.js", "remote-content")
     this.assertContextKeyMapsToIdentifier("./date_range_editor_controller.js", "date-range-editor")
   }
 
-  "test slashes map to two dashes"() {
-    this.assertContextKeyMapsToIdentifier("./users/list_item_controller.js", "users--list-item")
-    this.assertContextKeyMapsToIdentifier("./my/navigation/menu_controller.js", "my--navigation--menu")
+  "test directory slashes map to one dot"() {
+    this.assertContextKeyMapsToIdentifier("./users/list_item_controller.js", "users.list-item")
+    this.assertContextKeyMapsToIdentifier("./my/navigation/menu_controller.js", "my.navigation.menu")
   }
 
   assertContextKeyMapsToIdentifier(contextKey: string, expectedIdentifier?: string) {


### PR DESCRIPTION
If we have controllers like so: 

```yml
controllers: 
  admin: 
      - reference_controller.js 
  app: 
      - reference_controller.js 
```

```js
const context = require.context('../controllers', true, /\.js$/)
application.load(definitionsFromContext(context))
```

It's not clear how to add them to views.

After some digging, I figured that we could do this `admin--reference` which is unintuitive and inconsistent since we are using `.` notation for `target` and `action` referencing. 

```html
<div data-controller="admin--reference.someTarget"></div>
<div data-controller="app--reference"></div>
```

This PR changes `--` to `.` to support namespaced controllers. 

--- 

Also, I am wondering, 

1. Do we need a `_controller` suffix? Wouldn't it be easier if it's just called `something.js` and then perhaps we can verify after module load that it's indeed a stimulus controller instance? 

2. If we have a layout like this: 

```
reference: 
      - reference.sass
      - _reference.html.erb
      - reference_controller.js 
```

Then, the identifier becomes repetitive: 

<div data-controller="referencee.reference.target"></div>
<div data-controller="reference.reference"></div>

So, would it makes sense we make controllers globally unique and use only the filename as an identifier? 


