### PR TITLE
Add a "Security Considerations" document to the repo root

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # Security Considerations
 
 ### Q: Can I be confident that if my cross-site scripting countermeasures fail, there is no way for an attacker to run arbitrary JavaScript using Stimulus?
-A: While there is no way for an attacker to run arbitrary JavaScript using Stimulus, if an attacker can insert or modify DOM elements on your page, they can use the `data-action` attribute to define an action that invokes an arbitrary method on one of your controllers in response to an event.
+A: While there is no way for an attacker to run arbitrary JavaScript using Stimulus, if an attacker can insert or modify DOM elements on your page, they can use the `data-action` attribute to [define an action](docs/reference/actions.md) that invokes an arbitrary method on one of your controllers in response to an event.
 
 ### Q: If an attacker manages to make changes to my application's DOM, how can I ensure that what they can do is limited if I use Stimulus?
-A: Ensure that none of the methods on any of your controllers performs sensitive operations without appropriate safeguards.
+A: Ensure that none of the methods on any of your controllers perform sensitive operations without appropriate safeguards.
 
 Refer to the MDN [Content Security Policy documentation](https://content-security-policy.com) for a general overview of cross-site scripting attacks and how to defend against them.
 
@@ -12,4 +12,4 @@ Refer to the MDN [Content Security Policy documentation](https://content-securit
 A: Yes. All controller classes must be registered with corresponding identifiers, either implicitly by way of the `@stimulus/webpack-helpers` package or explicitly through a call to `Application#register()`.
 
 ### Q: Does Stimulus use `eval()`?
-A: No. There is no use of `eval()` in Stimulus. The action system _does_ use dynamic dispatch to invoke controller methods, which corresponds to a runtime property lookup on the controller instance. See the implementation of the [`Binding#method getter`](packages/@stimulus/core/src/binding.ts) for details.
+A: No. There is no use of `eval()` in Stimulus. The action system _does_ use dynamic dispatch to invoke controller methods, which corresponds to a runtime property lookup on the controller instance. See the implementation of [`Binding#method`](packages/@stimulus/core/src/binding.ts) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Considerations
+
+### Q: Can I be confident that if my cross-site scripting countermeasures fail, there is no way for an attacker to run arbitrary JavaScript using Stimulus?
+A: While there is no way for an attacker to run arbitrary JavaScript using Stimulus, if an attacker can insert or modify DOM elements on your page, they can use the `data-action` attribute to define an action that invokes an arbitrary method on one of your controllers in response to an event.
+
+### Q: If an attacker manages to make changes to my application's DOM, how can I ensure that what they can do is limited if I use Stimulus?
+A: Ensure that none of the methods on any of your controllers performs sensitive operations without appropriate safeguards.
+
+Refer to the MDN [Content Security Policy documentation](https://content-security-policy.com) for a general overview of cross-site scripting attacks and how to defend against them.
+
+### Q: Will Stimulus only instantiate and invoke methods on classes marked as controllers?
+A: Yes. All controller classes must be registered with corresponding identifiers, either implicitly by way of the `@stimulus/webpack-helpers` package or explicitly through a call to `Application#register()`.
+
+### Q: Does Stimulus use `eval()`?
+A: No. There is no use of `eval()` in Stimulus. The action system _does_ use dynamic dispatch to invoke controller methods, which corresponds to a runtime property lookup on the controller instance. See the implementation of the [`Binding#method getter`](packages/@stimulus/core/src/binding.ts) for details.


### PR DESCRIPTION
This branch pulls in answers to the questions posed by @david-a-wheeler in this thread: https://discourse.stimulusjs.org/t/security-csp-and-stimulus/171

I think it's good to publish these answers, but after some consideration I don't think they need to be elevated to the same level as controllers, actions, and targets in our [current](https://stimulusjs.org/handbook/introduction) [documentation](https://stimulusjs.org/reference/controllers) site (#125).

Instead, I've compiled them into a SECURITY.md file at the root of the repository, where they should be obvious if you're looking for them, and less alarming if not.

/cc @jeremy 