### PR TITLE
Remove suggestion to use stage-2 preset from handbook

### DIFF
--- a/docs/handbook/06_installing_stimulus.md
+++ b/docs/handbook/06_installing_stimulus.md
@@ -71,15 +71,6 @@ If you're using [Babel](https://babeljs.io/) with your build system, you'll need
 }
 ```
 
-Or, use the [stage-2 preset](https://babeljs.io/docs/plugins/preset-stage-2/), which includes the transform-class-properties plugin and more:
-
-```js
-// .babelrc
-{
-  "presets": ["env", "stage-2"]
-}
-```
-
 ## Using Without a Build System
 
 If you prefer not to use a build system, you can load Stimulus in a `<script>` tag and it will be globally available through the `window.Stimulus` object.


### PR DESCRIPTION
Babel 7 has been released, and the stage presets have been deprecated/discontinued:

https://babeljs.io/blog/2018/08/27/7.0.0#major-breaking-changes
https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets

Since Babel no longer recommends/supports using the stage presets, I think it makes sense to remove this from the Stimulus handbook.