### PR TITLE
Add summary of naming conventions to docs

### DIFF
--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -1,0 +1,19 @@
+---
+permalink: /reference/naming
+order: 05
+---
+
+# Naming
+
+A summary of Stimulus naming conventions:
+
+| Component              | Convention      | Rationale                                                                                                     |
+|------------------------|-----------------|---------------------------------------------------------------------------------------------------------------|
+| Controller filenames   | `snake_case.js` | Rails works that way                                                                                          |
+| Identifiers            | `kebab-case`    | Sometimes used as part of HTML attribute names; analogous to CSS classes, which are conventionally kebab-case |
+| Action names           | `camelCase`     | Map directly to JavaScript controller methods                                                                 |
+| Target names           | `camelCase`     | Map directly to JavaScript controller properties                                                              |
+| Data attributes (JS)   | `camelCase`     | Thin wrapper around the [HTMLElement.dataSet API][dataset-api]                                                |
+| Data attributes (HTML) | `kebab-case`    | Thin wrapper around the [HTMLElement.dataSet API][dataset-api]                                                |
+
+[dataset-api]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset


### PR DESCRIPTION
I really like the Stimulus docs, but found myself flicking between each of the 'Reference' pages to read each Naming Convention section.

Then I found this really helpful comment:
https://github.com/stimulusjs/stimulus/issues/70#issuecomment-359991756

Perhaps a birds-eye summary of the naming conventions be added to the docs?