### PR TITLE
Correctly separate out webpack-helpers.d.ts

### DIFF
--- a/packages/stimulus/index.d.ts
+++ b/packages/stimulus/index.d.ts
@@ -1,2 +1,1 @@
 export * from "@stimulus/core"
-export * from "@stimulus/webpack-helpers"

--- a/packages/stimulus/webpack-helpers.d.ts
+++ b/packages/stimulus/webpack-helpers.d.ts
@@ -1,0 +1,1 @@
+export * from "@stimulus/webpack-helpers"


### PR DESCRIPTION
The webpack install code from https://stimulusjs.org/handbook/installing is for javascript. It should work for typescript too if the extension is changed from js to ts, but it generates the following error:

```
ERROR in /Users/peterfaiman/code/stimulus-example/src/index.ts
[tsl] ERROR in /Users/peterfaiman/code/stimulus-example/src/index.ts(2,40)
      TS7016: Could not find a declaration file for module 'stimulus/webpack-helpers'. '/Users/peterfaiman/code/stimulus-example/node_modules/stimulus/webpack-helpers.js' implicitly has an 'any' type.
```

Typescript finds the declaration once moved to `webpack-helpers.d.ts`.