### PR TITLE
Add default value param to `get` method of Data Map API

### DIFF
--- a/packages/@stimulus/core/src/data_map.ts
+++ b/packages/@stimulus/core/src/data_map.ts
@@ -15,9 +15,12 @@ export class DataMap {
     return this.scope.identifier
   }
 
-  get(key: string): string | null {
-    key = this.getFormattedKey(key)
-    return this.element.getAttribute(key)
+  get(key: string, defaultValue = null): string | null {
+    if (this.has(key)) {
+      key = this.getFormattedKey(key)
+      return this.element.getAttribute(key)
+    }
+    return defaultValue
   }
 
   set(key: string, value: string): string | null {


### PR DESCRIPTION
To make possible add optional data attributes.

```js
export default class extends Controller {
  static classes = [ "success", "supported" ]

  initialize() {
    // returns 1 if data-controller-index not exists
    const index = this.data.get('index', 1) 
    this.foo(index);
  }
}
```