### PR TITLE
Fix for DataMap set() method always returning null

### DIFF
--- a/packages/@stimulus/core/src/data_map.ts
+++ b/packages/@stimulus/core/src/data_map.ts
@@ -16,25 +16,25 @@ export class DataMap {
   }
 
   get(key: string): string | null {
-    key = this.getFormattedKey(key)
-    return this.element.getAttribute(key)
+    const formattedKey = this.getFormattedKey(key)
+    return this.element.getAttribute(formattedKey)
   }
 
   set(key: string, value: string): string | null {
-    key = this.getFormattedKey(key)
-    this.element.setAttribute(key, value)
+    const formattedKey = this.getFormattedKey(key)
+    this.element.setAttribute(formattedKey, value)
     return this.get(key)
   }
 
   has(key: string): boolean {
-    key = this.getFormattedKey(key)
-    return this.element.hasAttribute(key)
+    const formattedKey = this.getFormattedKey(key)
+    return this.element.hasAttribute(formattedKey)
   }
 
   delete(key: string): boolean {
     if (this.has(key)) {
-      key = this.getFormattedKey(key)
-      this.element.removeAttribute(key)
+      const formattedKey = this.getFormattedKey(key)
+      this.element.removeAttribute(formattedKey)
       return true
     } else {
       return false

--- a/packages/@stimulus/core/src/tests/cases/data_tests.ts
+++ b/packages/@stimulus/core/src/tests/cases/data_tests.ts
@@ -15,7 +15,7 @@ export default class DataTests extends BareControllerTestCase {
   }
 
   "test DataSet#set"() {
-    this.controller.data.set("alpha", "ok")
+    this.assert.equal(this.controller.data.set("alpha", "ok"), "ok")
     this.assert.equal(this.controller.data.get("alpha"), "ok")
     this.assert.equal(this.findElement("div").getAttribute(`data-${this.identifier}-alpha`), "ok")
   }


### PR DESCRIPTION
This was caused by the key parameter being mutated to the formatted version before being passed into get - causing it to never be found