### PR TITLE
Optimize finding singular target elements

### DIFF
--- a/packages/@stimulus/core/src/scope.ts
+++ b/packages/@stimulus/core/src/scope.ts
@@ -19,21 +19,24 @@ export class Scope {
   }
 
   findElement(selector: string): Element | undefined {
-    return this.findAllElements(selector)[0]
+    return this.element.matches(selector)
+      ? this.element
+      : this.queryElements(selector).find(this.containsElement)
   }
 
   findAllElements(selector: string): Element[] {
-    const head = this.element.matches(selector) ? [this.element] : []
-    const tail = this.filterElements(Array.from(this.element.querySelectorAll(selector)))
-    return head.concat(tail)
+    return [
+      ...this.element.matches(selector) ? [this.element] : [],
+      ...this.queryElements(selector).filter(this.containsElement)
+    ]
   }
 
-  filterElements(elements: Element[]): Element[] {
-    return elements.filter(element => this.containsElement(element))
-  }
-
-  containsElement(element: Element) {
+  containsElement = (element: Element): boolean => {
     return element.closest(this.controllerSelector) === this.element
+  }
+
+  private queryElements(selector: string): Element[] {
+    return Array.from(this.element.querySelectorAll(selector))
   }
 
   private get controllerSelector(): string {


### PR DESCRIPTION
Tested (somewhat unscientifically) using the following markup nested several levels deep:
```html
<div data-controller="x" data-target="x.a">
  <span>
    <span data-target="x.b"></span>
    <span data-target="x.b"></span>
  </span>

  <span data-target="x.c"></span>
  <span data-target="x.c"></span>

  <div data-controller="x" data-target="x.a">
    …
  </div>
</div>
```

Before:
```
this.aTarget 0.140ms
this.bTarget 0.230ms
this.cTarget 0.160ms
```

After:
```
this.aTarget 0.035ms
this.bTarget 0.140ms
this.cTarget 0.110ms
```