### PR TITLE
Remove Typescript build info during cleanup

### DIFF
--- a/packages/@stimulus/core/package.json
+++ b/packages/@stimulus/core/package.json
@@ -23,6 +23,6 @@
     "@stimulus/test": "^1.1.1"
   },
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }

--- a/packages/@stimulus/multimap/package.json
+++ b/packages/@stimulus/multimap/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }

--- a/packages/@stimulus/mutation-observers/package.json
+++ b/packages/@stimulus/mutation-observers/package.json
@@ -21,6 +21,6 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }

--- a/packages/@stimulus/test/package.json
+++ b/packages/@stimulus/test/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }

--- a/packages/@stimulus/webpack-helpers/package.json
+++ b/packages/@stimulus/webpack-helpers/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist *.tsbuildinfo"
   }
 }


### PR DESCRIPTION
fix #267 

After manually removing `.tsbuildinfo` files, I could build again the project. 
This PR adds the `*.tsbuildinfo` to the list of files to clean when doing a `yarn clean` 
