### PR TITLE
Fix closing tag in installation documentation

### DIFF
--- a/docs/handbook/06_installing_stimulus.md
+++ b/docs/handbook/06_installing_stimulus.md
@@ -96,7 +96,7 @@ Define targets using `static get targets()` methods instead of `static targets =
       })
     })()
   </script>
-<head>
+</head>
 <body>
   <div data-controller="hello">
     <input data-target="hello.name" type="text">


### PR DESCRIPTION
A minor fix to add a `/` to the closing `</head>` tag in the installation guide.