### PR TITLE
Improve Naming Conventions documents

### DIFF
--- a/docs/reference/controllers.md
+++ b/docs/reference/controllers.md
@@ -92,7 +92,7 @@ Always use camelCase for method and property names in a controller class.
 
 When an identifier is composed of more than one word, write the words in kebab-case (i.e., by using dashes: `date-picker`, `list-item`).
 
-In filenames, separate multiple words using either dashes or underscores (kebab-case or snake_case: `controllers/date_picker.js`, `controllers/list-item.js`).
+In filenames, separate multiple words using either underscores or dashes (snake_case or kebab-case: `controllers/date_picker_controller.js`, `controllers/list-item-controller.js`).
 
 ## Registration
 


### PR DESCRIPTION
Hi 👋 

This Pull Request improves [naming conventions] doc. Two changes

- Mention snake_case first since it got used more frequently in the docs
- Add `_controller.js` suffix to filenames

Before

<img width="780" alt="スクリーンショット 2020-03-15 13 39 08" src="https://user-images.githubusercontent.com/1000669/76695419-69075c00-66c2-11ea-96d9-313456044d66.png">

After

<img width="774" alt="スクリーンショット 2020-03-17 10 04 19" src="https://user-images.githubusercontent.com/1000669/76811955-b4db1200-6836-11ea-8928-b55a7772b68e.png">


[naming conventions]: https://stimulusjs.org/reference/controllers#naming-conventions