### PR TITLE
Add Symbol.iterator to stimulus polyfills

### DIFF
--- a/packages/@stimulus/polyfills/README.md
+++ b/packages/@stimulus/polyfills/README.md
@@ -1,6 +1,7 @@
 The `@stimulus/polyfills` package provides support for Stimulus in older browsers like Internet Explorer 11 and Safari 9.
 
 * [core-js](https://www.npmjs.com/package/core-js)
+  * `Symbol.iterator`
   * `Array.find()`
   * `Array.findIndex()`
   * `Array.from()`
@@ -14,4 +15,3 @@ The `@stimulus/polyfills` package provides support for Stimulus in older browser
   * `MutationObserver` support for Internet Explorer 11
 * [eventlistener-polyfill](https://github.com/github/eventlistener-polyfill)
   * once & passive support for Internet Explorer 11 & Edge
-  

--- a/packages/@stimulus/polyfills/index.js
+++ b/packages/@stimulus/polyfills/index.js
@@ -1,3 +1,4 @@
+import "core-js/es/symbol/iterator"
 import "core-js/es/array/find"
 import "core-js/es/array/find-index"
 import "core-js/es/array/from"


### PR DESCRIPTION
Propose a fix for #329 

Fixing an error where loading google maps on IE 11 would throw an error preventing stimulus controllers to properly load.