### PR TITLE
Account for HTML escaped ActionDescriptor Syntax

### DIFF
--- a/packages/@stimulus/core/src/action_descriptor.ts
+++ b/packages/@stimulus/core/src/action_descriptor.ts
@@ -6,8 +6,8 @@ export interface ActionDescriptor {
   methodName: string
 }
 
-// capture nos.:            12   23 4               43 5        51 6   67 8      879 X  X9
-const descriptorPattern = /^((.+?)(@(window|document))?(->|-&gt;))?(.+?)(#([^:]+?))(:(.+))?$/
+// capture nos.:            12   23 4               43   1 5   56 7      768 9  98
+const descriptorPattern = /^((.+?)(@(window|document))?->)?(.+?)(#([^:]+?))(:(.+))?$/
 
 export function parseDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()
@@ -15,9 +15,9 @@ export function parseDescriptorString(descriptorString: string): Partial<ActionD
   return {
     eventTarget:  parseEventTarget(matches[4]),
     eventName:    matches[2],
-    eventOptions: matches[10] ? parseEventOptions(matches[10]) : {},
-    identifier:   matches[6],
-    methodName:   matches[8]
+    eventOptions: matches[9] ? parseEventOptions(matches[9]) : {},
+    identifier:   matches[5],
+    methodName:   matches[7]
   }
 }
 

--- a/packages/@stimulus/core/src/action_descriptor.ts
+++ b/packages/@stimulus/core/src/action_descriptor.ts
@@ -6,8 +6,8 @@ export interface ActionDescriptor {
   methodName: string
 }
 
-// capture nos.:            12   23 4               43   1 5   56 7      768 9  98
-const descriptorPattern = /^((.+?)(@(window|document))?->)?(.+?)(#([^:]+?))(:(.+))?$/
+// capture nos.:            12   23 4               43 5        51 6   67 8      879 X  X9
+const descriptorPattern = /^((.+?)(@(window|document))?(->|-&gt;))?(.+?)(#([^:]+?))(:(.+))?$/
 
 export function parseDescriptorString(descriptorString: string): Partial<ActionDescriptor> {
   const source = descriptorString.trim()
@@ -15,9 +15,9 @@ export function parseDescriptorString(descriptorString: string): Partial<ActionD
   return {
     eventTarget:  parseEventTarget(matches[4]),
     eventName:    matches[2],
-    eventOptions: matches[9] ? parseEventOptions(matches[9]) : {},
-    identifier:   matches[5],
-    methodName:   matches[7]
+    eventOptions: matches[10] ? parseEventOptions(matches[10]) : {},
+    identifier:   matches[6],
+    methodName:   matches[8]
   }
 }
 

--- a/packages/@stimulus/core/src/tests/cases/action_tests.ts
+++ b/packages/@stimulus/core/src/tests/cases/action_tests.ts
@@ -5,6 +5,7 @@ export default class ActionTests extends LogControllerTestCase {
   fixtureHTML = `
     <div data-controller="c" data-action="keydown@window->c#log">
       <button data-action="c#log"><span>Log</span></button>
+      <button type="button" id="escaped" data-action="click-&gt;c#log"></button>
       <div id="outer" data-action="click->c#log">
         <div id="inner" data-controller="c" data-action="click->c#log keyup@window->c#log"></div>
       </div>
@@ -18,6 +19,11 @@ export default class ActionTests extends LogControllerTestCase {
 
   async "test default event"() {
     await this.triggerEvent("button", "click")
+    this.assertActions({ name: "log", eventType: "click" })
+  }
+
+  async "test escaped action"() {
+    await this.triggerEvent("#escaped", "click")
     this.assertActions({ name: "log", eventType: "click" })
   }
 


### PR DESCRIPTION
Some frameworks (e.g. Rails and [Rack][]) will HTML escape attributes.
This can result in typical action routing attributes to be transformed
and broken:

```html+erb
<button data-action="<%= an_escaping_method("click->controller#action") %>"></button>

<%# => <button data-action="click-&gt;controller#action"></button> %>
```

This commit expands the Action Descriptor syntax to account for
escaping.

In the case of Rack, there is a small collection of HTML escaped
characters:

* `&` escapes into `&amp;`
* `<` escapes into `&lt;`
* `>` escapes into `&gt;`
* `'` escapes into `&#x27;`
* `"` escapes into `&quot;`
* `/` escapes into `&#x2F;`

Of those characters, the `>` is the only one currently part of the
Stimulus syntax.

[Rack]: https://www.rubydoc.info/github/rack/rack/Rack/Utils#ESCAPE_HTML-constant