### PR TITLE
Make sure to also run `build:test` in the `build` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
   "scripts": {
     "clean": "rm -fr dist",
     "types": "tsc --noEmit false --declaration true --emitDeclarationOnly true --outDir dist/types",
+    "prebuild": "yarn build:test",
     "build": "yarn types && rollup -c",
     "build:test": "tsc -b tsconfig.test.json",
     "watch": "rollup -wc",
-    "prerelease": "yarn build && git --no-pager diff && echo && npm pack --dry-run",
+    "prerelease": "yarn clean && yarn build && yarn build:test && git --no-pager diff && echo && npm pack --dry-run",
     "release": "npm publish",
     "start": "concurrently \"npm:watch\" \"npm:start:examples\"",
     "start:examples": "cd examples && yarn install && node server.js",


### PR DESCRIPTION
This pull request makes sure that the `build:test` command is also run as part of the `build` and `release` step.

This way developers (especially plugin developers) can import all Stimulus' classes and types even if they are not publicly exported. We are not guaranteeing that those exports are non-breaking, but at least this will allow developers to make use of those classes even if we are not explicitly exporting them.

Importing classes would look something like:
```js
import { Controller } from "@hotwired/stimulus"
import { TargetSet } from "@hotwired/stimulus/dist/core/target_set"
import { Context } from "@hotwired/stimulus/dist/core/context"
```

And types could be imported like:
```ts
import type { TargetSet } from "@hotwired/stimulus/dist/types/core/target_set"
import type { Context } from "@hotwired/stimulus/dist/types/core/context"
```

Resolves https://github.com/hotwired/stimulus/pull/623 and https://github.com/hotwired/stimulus/issues/638