### PR TITLE
Do not ScopeObserver#scopeReferenceCounts when outlet is called before controller is connected

### DIFF
--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -31,8 +31,11 @@ export class Module {
 
   connectContextForScope(scope: Scope) {
     const context = this.fetchContextForScope(scope)
-    this.connectedContexts.add(context)
-    context.connect()
+
+    if (!this.connectedContexts.has(context)) {
+      this.connectedContexts.add(context)
+      context.connect()
+    }
   }
 
   disconnectContextForScope(scope: Scope) {

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -79,7 +79,7 @@ export class Router implements ScopeObserverDelegate {
     const scope = this.scopeObserver.parseValueForElementAndIdentifier(element, identifier)
 
     if (scope) {
-      this.scopeObserver.elementMatchedValue(scope.element, scope)
+      this.scopeConnected(scope)
     } else {
       console.error(`Couldn't find or create scope for identifier: "${identifier}" and element:`, element)
     }


### PR DESCRIPTION
Fixes https://github.com/hotwired/stimulus/issues/763

The problem occurs when Outlet is accessed before controller has been connected by Stimulus and somebody tries to disconnect such controller later.

in such case `ScopeObserver#elementMatchedValue` is called 2 times so `this.scopeReferenceCounts` is eq 2.
and during `ScopeObserver#elementUnmatchedValue` this counter `this.scopeReferenceCounts` remains >= 1 so `scopeDisconnected(value)` is not called

