### PR TITLE
Fix: A potential TypeError due to shadowed contains in ElementObserve

### DIFF
--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -96,11 +96,15 @@ export class Binding {
 
     if (this.element === eventTarget) {
       return true
-    } else if (eventTarget instanceof Element && this.element.contains(eventTarget)) {
+    } else if (eventTarget instanceof Element && this.containsElement(eventTarget)) {
       return this.scope.containsElement(eventTarget)
     } else {
       return this.scope.containsElement(this.action.element)
     }
+  }
+
+  private containsElement(element: Element): boolean {
+    return HTMLElement.prototype.contains.call(this.element, element)
   }
 
   private get controller(): Controller {

--- a/src/mutation-observers/element_observer.ts
+++ b/src/mutation-observers/element_observer.ts
@@ -146,7 +146,7 @@ export class ElementObserver {
     if (element.isConnected != this.element.isConnected) {
       return false
     } else {
-      return this.element.contains(element)
+      return this.containsElement(element)
     }
   }
 
@@ -170,5 +170,9 @@ export class ElementObserver {
         this.delegate.elementUnmatched(element)
       }
     }
+  }
+
+  private containsElement(element: Element): boolean {
+    return HTMLElement.prototype.contains.call(this.element, element)
   }
 }


### PR DESCRIPTION
This PR fixes a potential `TypeError: this.element.contains is not a function` error in `ElementObserver`. This error can occur if a child element shadows the native `contains` method.

To resolve this, the PR replaces `this.element.contains(element)` with `HTMLElement.prototype.contains.call(this.element, element)` in the `elementIsActive` method. This ensures that the native `contains` method is always called, regardless of any naming conflicts.

For example, consider the following HTML:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
    <script type="module">
      import {
        Application,
        Controller,
      } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js";
      window.Stimulus = Application.start();

      function debounce(fn, delay = 1000) {
        let timeoutId = null;

        return (...args) => {
          clearTimeout(timeoutId);
          timeoutId = setTimeout(() => fn.apply(this, args), delay);
        };
      }

      Stimulus.register(
        "form",
        class extends Controller {
          initialize() {
            this.submit = debounce(this.submit.bind(this), 300);
          }

          submit() {
            this.element.requestSubmit();
          }
        },
      );
    </script>
  </head>
  <body>
    <form action="/search" method="get" data-controller="form">
      <input type="search" name="contains" data-action="form#submit" />
    </form>
  </body>
</html>

```

In this case, the `<input name="contains">` shadows the native `contains` method on the `<form>` element, leading to a `TypeError: this.element.contains is not a function` error at runtime.