### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:20
+
+# Install Chrome and Firefox
+RUN apt-get update && apt-get install -y firefox-esr chromium \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Stimulus DevContainer",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "yarn install",
+  "containerEnv": {
+    "CHROME_BIN": "/usr/bin/chromium"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I've been living the #nobuild lifestyle, so when I had an idea for a feature I could contribute to Stimulus I didn't want to have to install any javascript development dependencies on my local machine. This PR makes it possible to do that.