### PR TITLE
Add custom input action option

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -170,6 +170,7 @@ Custom action option | Description
 `:stop`              | calls `.stopPropagation()` on the event before invoking the method
 `:prevent`           | calls `.preventDefault()` on the event before invoking the method
 `:self`              | only invokes the method if the event was fired by the element itself
+`:!input`            | suppress an event if it was fired while an input element has focus
 
 You can register your own action options with the `Application.registerActionOption` method.
 

--- a/src/core/action_descriptor.ts
+++ b/src/core/action_descriptor.ts
@@ -30,6 +30,19 @@ export const defaultActionDescriptorFilters: ActionDescriptorFilters = {
       return true
     }
   },
+
+  input({ event, value }) {
+    if (value) return true
+
+    const target = event.target
+    if (!(target instanceof Element)) return true
+
+    const isInput =
+      target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    return !isInput
+  },
 }
 
 export interface ActionDescriptor {

--- a/src/tests/modules/core/event_options_tests.ts
+++ b/src/tests/modules/core/event_options_tests.ts
@@ -7,6 +7,7 @@ export default class EventOptionsTests extends LogControllerTestCase {
     <div data-controller="c d">
       <button></button>
       <details></details>
+      <input>
     </div>
     <div id="outside"></div>
   `
@@ -178,6 +179,22 @@ export default class EventOptionsTests extends LogControllerTestCase {
     this.assertNoActions()
   }
 
+  async "test true input option"() {
+    await this.setAction(this.inputElement, "keydown@window->c#log:input")
+
+    await this.triggerEvent(this.inputElement, "keydown")
+
+    this.assertActions({ name: "log", eventType: "keydown" })
+  }
+
+  async "test false input option"() {
+    await this.setAction(this.inputElement, "keydown@window->c#log:!input")
+
+    await this.triggerEvent(this.inputElement, "keydown")
+
+    this.assertNoActions()
+  }
+
   async "test custom action option callback params contain the controller instance"() {
     let lastActionOptions: { controller?: Controller<Element> } = {}
 
@@ -312,5 +329,9 @@ export default class EventOptionsTests extends LogControllerTestCase {
 
   get detailsElement() {
     return this.findElement("details")
+  }
+
+  get inputElement() {
+    return this.findElement("input")
   }
 }


### PR DESCRIPTION
As a Vim user, I love adding global hotkeys to my applications. However, it currently requires a custom solution to prevent those global hotkeys from firing when typing in input fields. This introduces a new custom event option to optionally suppress those events if an input element has focus.

Not specifying the option remains unchanged, it fires regardless of which element has focus.
`<div data-controller="menu" data-action="keydown.o@window->menu#open">`

You can explicitly state that the event should fire even if an input element has focus.
`<div data-controller="menu" data-action="keydown.o@window->menu#open:input">`

You can suppress an event if an input element has focus.
`<div data-controller="menu" data-action="keydown.o@window->menu#open:!input">`