### PR TITLE
Fix Chrome autocomplete incorrectly triggerring actions

### DIFF
--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -86,8 +86,13 @@ export class Binding {
   private willBeInvokedByEvent(event: Event): boolean {
     const eventTarget = event.target
 
-    if (event instanceof KeyboardEvent && this.action.shouldIgnoreKeyboardEvent(event)) {
-      return false
+    if (event.type === "keydown") {
+      // when accepting an autocomplete suggestion, Chrome dispatches a keydown event,
+      // but it isn't a KeyboardEvent instance
+      const keyboardEvent: KeyboardEvent = event instanceof KeyboardEvent ? event : new KeyboardEvent("keydown")
+      if (this.action.shouldIgnoreKeyboardEvent(keyboardEvent)) {
+        return false
+      }
     }
 
     if (event instanceof MouseEvent && this.action.shouldIgnoreMouseEvent(event)) {

--- a/src/tests/modules/core/action_keyboard_filter_tests.ts
+++ b/src/tests/modules/core/action_keyboard_filter_tests.ts
@@ -197,4 +197,12 @@ export default class ActionKeyboardFilterTests extends LogControllerTestCase {
     await this.triggerEvent(button, "jquery.a")
     this.assertActions({ name: "log2", identifier: "a", eventType: "jquery.a", currentTarget: button })
   }
+
+  async "test ignore events dispatched by autocomplete"() {
+    const button = this.findElement("#button10")
+    await this.nextFrame
+    await this.triggerEvent(button, "keydown", {})
+
+    this.assertNoActions()
+  }
 }


### PR DESCRIPTION
When using a Stimulus action like

    <button data-action="keydown.meta+k@window->search#open">

in Google Chrome, clicking an input's autocomplete suggestion unexpectedly triggers the controller action even though no key is pressed.

It seems that Chrome dispatches an Event with type === "keydown", but it is not an instance of KeyboardEvent. This happens regardless of the key filter.

Closes #852