### PR TITLE
Add findElement and findAllElments methods to controllers

### DIFF
--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -73,6 +73,14 @@ export class Controller<ElementType extends Element = Element> {
     return this.scope.data
   }
 
+  findElement(selector: string) {
+    return this.scope.findElement(selector)
+  }
+
+  findAllElements(selector: string) {
+    return this.scope.findAllElements(selector)
+  }
+
   initialize() {
     // Override in your subclass to set up initial controller state
   }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -73,12 +73,18 @@ export class Controller<ElementType extends Element = Element> {
     return this.scope.data
   }
 
-  findElement(selector: string) {
-    return this.scope.findElement(selector)
+  findElement(selector: string): Element | undefined {
+    const elementWithId = document.getElementById(selector)
+    if (elementWithId && this.scope.containsElement(elementWithId)) {
+      return elementWithId
+    }
+    const newSelector = this.classifySelector(selector)
+    return this.scope.findElement(newSelector)
   }
 
-  findAllElements(selector: string) {
-    return this.scope.findAllElements(selector)
+  findAllElements(selector: string): Element[] {
+    const newSelector = this.classifySelector(selector)
+    return this.scope.findAllElements(newSelector)
   }
 
   initialize() {
@@ -107,5 +113,17 @@ export class Controller<ElementType extends Element = Element> {
     const event = new CustomEvent(type, { detail, bubbles, cancelable })
     target.dispatchEvent(event)
     return event
+  }
+
+  private classifySelector(selector: string | string[]): string {
+    const tokens = Array.isArray(selector) ? selector : [selector]
+
+    const definedClasses: string[] = (this.constructor as any).classes.flatMap((key: string) => {
+      const value = (this as any)[`${key}Classes`] as string[] | undefined
+      return value ?? []
+    })
+
+    const allTokensDefined = tokens.every((token) => definedClasses.includes(token))
+    return "." + tokens.join(allTokensDefined ? "." : " ")
   }
 }

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -44,18 +44,15 @@ export class Scope {
 
   classifySelector(selector: string | string[]): string {
     const tokens = Array.isArray(selector) ? selector : [selector]
-
-    const allDefinedTokens = this.getAllClassTokens()
-    const isDefinedClass = tokens.every((token) => allDefinedTokens.includes(token))
-
-    const stringySelector = tokens.join(" ")
-    return isDefinedClass ? `.${stringySelector.replace(/ /g, ".")}` : stringySelector
+    const definedTokens = new Set(this.getAllClassTokens())
+    const allTokensDefined = tokens.every((token) => definedTokens.has(token))
+    return tokens.join(allTokensDefined ? "." : " ")
   }
 
   getAllClassTokens(): string[] {
     return Object.entries((this.element as HTMLElement).dataset)
       .filter(([key]) => key.endsWith("Class"))
-      .flatMap(([_, value]) => (value ? value.trim().split(/\s+/) : []))
+      .flatMap(([, value]) => value?.trim().split(/\s+/) ?? [])
   }
 
   containsElement = (element: Element): boolean => {

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -26,14 +26,36 @@ export class Scope {
   }
 
   findElement(selector: string): Element | undefined {
-    return this.element.matches(selector) ? this.element : this.queryElements(selector).find(this.containsElement)
+    const elementWithId = document.getElementById(selector)
+    if (elementWithId && this.containsElement(elementWithId)) {
+      return elementWithId
+    }
+    const newSelector = this.classifySelector(selector)
+    return this.element.matches(newSelector) ? this.element : this.queryElements(newSelector).find(this.containsElement)
   }
 
   findAllElements(selector: string): Element[] {
+    const newSelector = this.classifySelector(selector)
     return [
-      ...(this.element.matches(selector) ? [this.element] : []),
-      ...this.queryElements(selector).filter(this.containsElement),
+      ...(this.element.matches(newSelector) ? [this.element] : []),
+      ...this.queryElements(newSelector).filter(this.containsElement),
     ]
+  }
+
+  classifySelector(selector: string | string[]): string {
+    const tokens = Array.isArray(selector) ? selector : [selector]
+
+    const allDefinedTokens = this.getAllClassTokens()
+    const isDefinedClass = tokens.every((token) => allDefinedTokens.includes(token))
+
+    const stringySelector = tokens.join(" ")
+    return isDefinedClass ? `.${stringySelector.replace(/ /g, ".")}` : stringySelector
+  }
+
+  getAllClassTokens(): string[] {
+    return Object.entries((this.element as HTMLElement).dataset)
+      .filter(([key]) => key.endsWith("Class"))
+      .flatMap(([_, value]) => (value ? value.trim().split(/\s+/) : []))
   }
 
   containsElement = (element: Element): boolean => {

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -26,19 +26,13 @@ export class Scope {
   }
 
   findElement(selector: string): Element | undefined {
-    const elementWithId = document.getElementById(selector)
-    if (elementWithId && this.containsElement(elementWithId)) {
-      return elementWithId
-    }
-    const newSelector = this.classifySelector(selector)
-    return this.element.matches(newSelector) ? this.element : this.queryElements(newSelector).find(this.containsElement)
+    return this.element.matches(selector) ? this.element : this.queryElements(selector).find(this.containsElement)
   }
 
   findAllElements(selector: string): Element[] {
-    const newSelector = this.classifySelector(selector)
     return [
-      ...(this.element.matches(newSelector) ? [this.element] : []),
-      ...this.queryElements(newSelector).filter(this.containsElement),
+      ...(this.element.matches(selector) ? [this.element] : []),
+      ...this.queryElements(selector).filter(this.containsElement),
     ]
   }
 

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -36,19 +36,6 @@ export class Scope {
     ]
   }
 
-  classifySelector(selector: string | string[]): string {
-    const tokens = Array.isArray(selector) ? selector : [selector]
-    const definedTokens = new Set(this.getAllClassTokens())
-    const allTokensDefined = tokens.every((token) => definedTokens.has(token))
-    return tokens.join(allTokensDefined ? "." : " ")
-  }
-
-  getAllClassTokens(): string[] {
-    return Object.entries((this.element as HTMLElement).dataset)
-      .filter(([key]) => key.endsWith("Class"))
-      .flatMap(([, value]) => value?.trim().split(/\s+/) ?? [])
-  }
-
   containsElement = (element: Element): boolean => {
     return element.closest(this.controllerSelector) === this.element
   }

--- a/src/tests/modules/core/find_element_test.ts
+++ b/src/tests/modules/core/find_element_test.ts
@@ -4,21 +4,20 @@ import { ControllerTestCase } from "../../cases/controller_test_case"
 export default class FindElementTests extends ControllerTestCase(ClassController) {
   fixtureHTML = `
     <div data-controller="${this.identifier}"
-      data-${this.identifier}-active-class="test--active"
+      data-${this.identifier}-active-class="active"
       data-${this.identifier}-loading-class="busy"
-      data-${this.identifier}-success-class="bg-green-400 border border-green-600"
     >
-      <div id="inside-id" class="busy"></div>
+      <div id="inside" class="busy"></div>
     </div>
-    <div id="outside-id" class="busy"></div>
+    <div id="outside" class="busy"></div>
 
     "test findElement finds element by id inside scope"() {
-      const result = this.controller.findElement("inside-id")
-      this.assert.equal(result?.id, "inside-id")
+      const result = this.controller.findElement("inside")
+      this.assert.equal(result?.id, "inside")
     }
 
     "test findElement does not find element by id outside scope"() {
-      const result = this.controller.findElement("outside-id")
+      const result = this.controller.findElement("outside")
       this.assert.equal(result, undefined)
     }
 

--- a/src/tests/modules/core/find_element_test.ts
+++ b/src/tests/modules/core/find_element_test.ts
@@ -1,0 +1,38 @@
+import { ClassController } from "../../controllers/class_controller"
+import { ControllerTestCase } from "../../cases/controller_test_case"
+
+export default class FindElementTests extends ControllerTestCase(ClassController) {
+  fixtureHTML = `
+    <div data-controller="${this.identifier}"
+      data-${this.identifier}-active-class="test--active"
+      data-${this.identifier}-loading-class="busy"
+      data-${this.identifier}-success-class="bg-green-400 border border-green-600"
+    >
+      <div id="inside-id" class="busy"></div>
+    </div>
+    <div id="outside-id" class="busy"></div>
+
+    "test findElement finds element by id inside scope"() {
+      const result = this.controller.findElement("inside-id")
+      this.assert.equal(result?.id, "inside-id")
+    }
+
+    "test findElement does not find element by id outside scope"() {
+      const result = this.controller.findElement("outside-id")
+      this.assert.equal(result, undefined)
+    }
+
+    "test findElement finds element by defined class"() {
+      const result = this.controller.findElement(this.controller.loadingClass)
+      this.assert.ok(result instanceof Element)
+      this.assert.ok(result?.classList.contains("busy"))
+    }
+
+    "test findAllElements returns multiple matches for defined class"() {
+      const results = this.controller.findAllElements(this.controller.loadingClass)
+      this.assert.ok(Array.isArray(results))
+      this.assert.equal(results.length, 1)
+      this.assert.ok(results[0].classList.contains("busy"))
+    }
+  `
+}


### PR DESCRIPTION
### Summary

- Added access to `findElement` and `FindAllElements` to the Controller class
- These already existed in the Scope class, but can now be accessed directly inside the controller
- Also added more functionality to the methods to allow finding by id and using Stimulus CSS classes

### Motivation

This was motivated by being frustrated by having to use `this.element.querySelector` to get access to elements based on their class or id and also having to prepend `.` to classes and `#` to ids. Using `document.getelementById` also didn't feel right, especially since it wasn't scoped to the root element of the controller.

This PR attempts to make the code look much more 'Stimulus' in style when selecting elements

### Usage

Given the following HTML:

```html
<div data-controller="my-controller"
      data-my-controller-active-class="active"
      data-my-controller-loading-classes="busy loading"
    >
      <div id="inside">This is inside</div>
      <div class="busy loading">This is loading</div>
      <div class="active"><p class="intro">This is the intro</p></div>
    </div>
    <div id="outside" class="busy">This is outside</div>
```

Find Elements scoped inside the root element by passing the id:

`this.findElement("inside")` will return  `<div id="inside" class="busy loading">...</div>`
`this.findElement("outside")` will return  `undefined` since it doesn't match any element inside the controller

Find elements using defined classes:

`this.getElement(this.activeClass)` will return  `<div class="active">...</div>`
`this.getElement(this.loadingClasses)` will return `<div class="busy loading">...</div>`

Find element using a standard query selector:

`this.getElement(.active p.intro)` will return `<p class="intro">...</p>`

The method looks for items with an id first, then looks to see if any classes have been defined on the controller and last of all falls back to using `this.element.querySelector`

`this.findAllElements` works in the same way, but returns an array of all matching elements. It does **not** look for elements with an id as there should only be one element with an id.