### PR TITLE
Log `Controller Not Found` when controller is not found.

### DIFF
--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -79,7 +79,12 @@ export class Application implements ErrorHandler {
 
   getControllerForElementAndIdentifier(element: Element, identifier: string): Controller | null {
     const context = this.router.getContextForElementAndIdentifier(element, identifier)
-    return context ? context.controller : null
+    if (context) {
+      return context.controller
+    } else {
+      this.logDebugActivity(identifier, "controller not found", { element })
+      return null
+    }
   }
 
   // Error handling

--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -79,12 +79,10 @@ export class Application implements ErrorHandler {
 
   getControllerForElementAndIdentifier(element: Element, identifier: string): Controller | null {
     const context = this.router.getContextForElementAndIdentifier(element, identifier)
-    if (context) {
-      return context.controller
-    } else {
-      this.logDebugActivity(identifier, "controller not found", { element })
-      return null
-    }
+    if (context) return context.controller
+
+    this.logDebugActivity(identifier, "controller not found", { element })
+    return null
   }
 
   // Error handling

--- a/src/tests/modules/core/application_tests.ts
+++ b/src/tests/modules/core/application_tests.ts
@@ -48,7 +48,7 @@ export default class ApplicationTests extends ApplicationTestCase {
   "test Application#getControllerForElementAndIdentifier logs debug activity when controller not found"() {
     this.application.load(this.definitions)
 
-    const logCalls: { identifier: string; functionName: string; detail: object }[] = []
+    const logCalls: { identifier: string; functionName: string; detail: { element?: Element } }[] = []
     this.application.logDebugActivity = (identifier, functionName, detail = {}) => {
       logCalls.push({ identifier, functionName, detail })
     }
@@ -60,6 +60,7 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.equal(logCalls.length, 1)
     this.assert.equal(logCalls[0].identifier, "nonexistent")
     this.assert.equal(logCalls[0].functionName, "controller not found")
+    this.assert.equal(logCalls[0].detail.element, element)
   }
 
   get controllers() {

--- a/src/tests/modules/core/application_tests.ts
+++ b/src/tests/modules/core/application_tests.ts
@@ -45,6 +45,23 @@ export default class ApplicationTests extends ApplicationTestCase {
     this.assert.ok(this.controllers[0] instanceof BController)
   }
 
+  "test Application#getControllerForElementAndIdentifier logs debug activity when controller not found"() {
+    this.application.load(this.definitions)
+
+    const logCalls: { identifier: string; functionName: string; detail: object }[] = []
+    this.application.logDebugActivity = (identifier, functionName, detail = {}) => {
+      logCalls.push({ identifier, functionName, detail })
+    }
+
+    const element = this.fixtureElement.querySelector("[data-controller='a']")!
+    const result = this.application.getControllerForElementAndIdentifier(element, "nonexistent")
+
+    this.assert.equal(result, null)
+    this.assert.equal(logCalls.length, 1)
+    this.assert.equal(logCalls[0].identifier, "nonexistent")
+    this.assert.equal(logCalls[0].functionName, "controller not found")
+  }
+
   get controllers() {
     return this.application.controllers as LogController[]
   }


### PR DESCRIPTION
related to #712 

This PR passes a missing controller name to the logging debugger and then returns `null`. Previously a missing controller simply returned `null` and swallowed the error, which made debugging difficult. Here we still swallow the error (no change in user facing function), but with logging to help the developers. 
