### PR TITLE
Introduce `actionHandlerMissing()` as a fallback when action handler methods aren't defined

### DIFF
--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -282,8 +282,7 @@ highlight(event) {
 
 ## Missing Action Handlers
 
-If the method specified by an action descriptor doesn't exist on the controller, Stimulus will call the special `actionHandlerMissing` method. You can override this method in your controller to dynamically handle events. The method receives the action and the event as arguments:
-
+If the method specified by an action descriptor doesn't exist on the controller, Stimulus will call the special `actionHandlerMissing` method. By default, `actionHandlerMissing` throws an error for the missing method, but you can override it in your controller to dynamically handle events. The method receives the action and the event as arguments:
 ```javascript
 actionHandlerMissing(action, event) {
   if (action.methodName === "next") {

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -280,6 +280,18 @@ highlight(event) {
 }
 ```
 
+## Missing Action Handlers
+
+If the method specified by an action descriptor doesn't exist on the controller, Stimulus will call the special `actionHandlerMissing` method. You can override this method in your controller to dynamically handle events. The method receives the action and the event as arguments:
+
+```javascript
+actionHandlerMissing(action, event) {
+  if (action.methodName === "next") {
+    // ...
+  }
+}
+```
+
 ## Naming Conventions
 
 Always use camelCase to specify action names, since they map directly to methods on your controller.

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -41,10 +41,14 @@ export class Binding {
 
   get method(): Function {
     const method = (this.controller as any)[this.methodName]
+
     if (typeof method == "function") {
       return method
     }
-    throw new Error(`Action "${this.action}" references undefined method "${this.methodName}"`)
+
+    return (event: ActionEvent) => {
+      this.controller.actionHandlerMissing(this.action, event)
+    }
   }
 
   private applyEventModifiers(event: Event): boolean {

--- a/src/core/binding.ts
+++ b/src/core/binding.ts
@@ -46,8 +46,10 @@ export class Binding {
       return method
     }
 
-    return (event: ActionEvent) => {
-      this.controller.actionHandlerMissing(this.action, event)
+    const action = this.action
+
+    return function (this: Controller, event: ActionEvent) {
+      this.actionHandlerMissing(action, event)
     }
   }
 

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -1,3 +1,5 @@
+import { Action } from "./action"
+import { ActionEvent } from "./action_event"
 import { Application } from "./application"
 import { ClassPropertiesBlessing } from "./class_properties"
 import { Constructor } from "./constructor"
@@ -99,5 +101,9 @@ export class Controller<ElementType extends Element = Element> {
     const event = new CustomEvent(type, { detail, bubbles, cancelable })
     target.dispatchEvent(event)
     return event
+  }
+
+  actionHandlerMissing(action: Action, _event: ActionEvent) {
+    throw new Error(`Action "${action}" references undefined method "${action.methodName}"`)
   }
 }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -1,5 +1,5 @@
-import { Action } from "./action"
-import { ActionEvent } from "./action_event"
+import type { Action } from "./action"
+import type { ActionEvent } from "./action_event"
 import { Application } from "./application"
 import { ClassPropertiesBlessing } from "./class_properties"
 import { Constructor } from "./constructor"

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+export { Action } from "./action"
 export { ActionEvent } from "./action_event"
 export { Application } from "./application"
 export { Context } from "./context"

--- a/src/tests/controllers/log_controller.ts
+++ b/src/tests/controllers/log_controller.ts
@@ -1,3 +1,4 @@
+import { Action } from "../../core/action"
 import { ActionEvent } from "../../core/action_event"
 import { Controller } from "../../core/controller"
 
@@ -54,6 +55,10 @@ export class LogController extends Controller {
   stop(event: ActionEvent) {
     this.recordAction("stop", event)
     event.stopImmediatePropagation()
+  }
+
+  actionHandlerMissing(action: Action, event: ActionEvent) {
+    this.recordAction(`${action.methodName}_missing`, event)
   }
 
   get actionLog() {

--- a/src/tests/controllers/log_controller.ts
+++ b/src/tests/controllers/log_controller.ts
@@ -1,4 +1,4 @@
-import { Action } from "../../core/action"
+import type { Action } from "../../core/action"
 import { ActionEvent } from "../../core/action_event"
 import { Controller } from "../../core/controller"
 

--- a/src/tests/modules/core/action_tests.ts
+++ b/src/tests/modules/core/action_tests.ts
@@ -5,7 +5,7 @@ export default class ActionTests extends LogControllerTestCase {
   fixtureHTML = `
     <div data-controller="c" data-action="keydown@window->c#log">
       <button data-action="c#log"><span>Log</span></button>
-      <div id="outer" data-action="click->c#log">
+      <div id="outer" data-action="click->c#log mousedown->c#iAmMissing">
         <div id="inner" data-controller="c" data-action="click->c#log keyup@window->c#log"></div>
       </div>
       <div id="multiple" data-action="click->c#log click->c#log2 mousedown->c#log"></div>
@@ -65,5 +65,10 @@ export default class ActionTests extends LogControllerTestCase {
     await this.triggerEvent("#svgRoot", "click")
     await this.triggerEvent("#svgChild", "mousedown")
     this.assertActions({ name: "log", eventType: "click" }, { name: "log", eventType: "mousedown" })
+  }
+
+  async "test missing actions routed through actionHandlerMissing"() {
+    await this.triggerEvent("#outer", "mousedown")
+    this.assertActions({ name: "iAmMissing_missing", eventType: "mousedown" })
   }
 }


### PR DESCRIPTION
Hello there 👋

First of all, thanks for Stimulus! This is the first time I've had the opportunity to look at the code, and I've really been enjoying it ❤️

### Intro

This PR is an attempt to add a default handler that can be overridden by derived controller classes to dynamically respond to action methods the controller doesn't define explicitly. It's modeled after Ruby's [`method_missing`](https://docs.ruby-lang.org/en/4.0/BasicObject.html#method-i-method_missing) feature, which enables objects to receive calls to methods that don't actually exist.

### Use-case

It might be helpful to hear a little about my use-case. I'm working on the [LiveComponent](https://livecomponent.org/) library, which uses Stimulus under the hood to automatically re-render parts of the page on the server when state changes. Live components also support a "reflex" feature, which allows calling arbitrary Ruby methods on the server (with safeguards, of course) just before re-render. Typically these reflex methods are called by action event handlers, but I would like to remove that level of indirection and automatically invoke reflexes on the server when action event handlers are called. This would entirely eliminate the need to define a custom controller for many Live components.

### Current solution

All this is probably better communicated by example. Consider the following Live component:

```typescript
import { LiveController } from "@camertron/live-component";

export class HelloComponent extends LiveController {
  greet() {
    this.render((component) => {
      // this results in calling the `greet` method on the server
      component.call("greet");
    });
  }
}
```

The `greet` method might be an action event handler invoked by Stimulus when eg. a button is clicked. Example markup:

```html
<button data-action="click->hello#greet">Greet</button>
```

### Proposed solution

A great deal of boilerplate can be stripped out if it's possible to dynamically handle action events in the `LiveController` base class. Here's how `LiveController` might make use of `actionHandlerMissing`:

```typescript
import { Controller, Action, ActionEvent } from "@hotwired/stimulus";

export class LiveController extends Controller {
  override actionHandlerMissing(action: Action, event: ActionEvent) {
    this.render((component) => {
      component.call(action.methodName);
    });
  }
}
```

Now action descriptors can be added to DOM elements without the need for a corresponding handler method.